### PR TITLE
Add typings and use List instead set() at domain_event_dispatcher

### DIFF
--- a/tests/winter_ddd/test_process_domain_events.py
+++ b/tests/winter_ddd/test_process_domain_events.py
@@ -150,4 +150,3 @@ def test_order_process_domain_events():
             'handle_many_2',
             'handle_many_3',
         ]
-

--- a/tests/winter_ddd/test_process_domain_events.py
+++ b/tests/winter_ddd/test_process_domain_events.py
@@ -3,7 +3,6 @@ from typing import Union
 
 import pytest
 
-from winter_ddd import AggregateRoot
 from winter_ddd import DomainEvent
 from winter_ddd import domain_event_handler
 from winter_ddd import global_domain_event_dispatcher
@@ -58,8 +57,48 @@ def empty_handler():
     yield Handler()
 
 
-class Aggregate(AggregateRoot):
+class DomainEventForOrder(DomainEvent):
     pass
+
+
+class OtherDomainEventForOrder(DomainEvent):
+    pass
+
+
+class OrderHandler1:
+    handled_domain_events = []
+
+    @domain_event_handler
+    def handle_one(self, domain_event: DomainEventForOrder):
+        self.handled_domain_events.append('handle_one_1')
+
+    @domain_event_handler
+    def handle_list_one(self, domain_events: List[DomainEventForOrder]):
+        self.handled_domain_events.append('handle_list_one_1')
+
+    @domain_event_handler
+    def handle_many(self, domain_events: List[Union[DomainEventForOrder, OtherDomainEventForOrder]]):
+        self.handled_domain_events.append('handle_many_1')
+
+
+class OrderHandler2:
+    handled_domain_events = []
+
+    @domain_event_handler
+    def handle_many(self, domain_events: List[Union[DomainEventForOrder, OtherDomainEventForOrder]]):
+        self.handled_domain_events.append('handle_many_2')
+
+
+class OrderHandler3:
+    handled_domain_events = []
+
+    @domain_event_handler
+    def handle_many(self, domain_events: Union[DomainEventForOrder, OtherDomainEventForOrder]):
+        self.handled_domain_events.append('handle_many_3')
+
+    @domain_event_handler
+    def handle_one(self, domain_event: DomainEventForOrder):
+        self.handled_domain_events.append('handle_one_3')
 
 
 def test_process_domain_events(empty_handler):
@@ -83,3 +122,32 @@ def test_process_domain_events(empty_handler):
     assert empty_handler.handled_many_another_domain_events == [[another_domain_event]]
     assert empty_handler.handled_union_domain_events == [domain_event1, another_domain_event, domain_event2]
     assert empty_handler.handled_union_list_domain_events == [[domain_event1, another_domain_event, domain_event2]]
+
+
+def test_order_process_domain_events():
+    domain_event = DomainEventForOrder()
+
+    handled_events = []
+    OrderHandler1.handled_domain_events = handled_events
+    OrderHandler2.handled_domain_events = handled_events
+    OrderHandler3.handled_domain_events = handled_events
+
+    # Act
+    for _ in range(5):
+        global_domain_event_dispatcher.dispatch([
+            domain_event,
+        ])
+
+    # Assert
+    while handled_events:
+        events = handled_events[:6]
+        del handled_events[:6]
+        assert events == [
+            'handle_one_1',
+            'handle_list_one_1',
+            'handle_one_3',
+            'handle_many_1',
+            'handle_many_2',
+            'handle_many_3',
+        ]
+

--- a/winter_ddd/domain_event_dispatcher.py
+++ b/winter_ddd/domain_event_dispatcher.py
@@ -18,7 +18,7 @@ EventFilter = Tuple[Type[DomainEvent]]
 class DomainEventDispatcher:
     def __init__(self):
         self._subscriptions: Dict[EventFilter, List[DomainEventSubscription]] = {}
-        self._event_type_to_event_filter_map: Dict[Type[DomainEvent], List[EventFilter]] = {}
+        self._event_type_to_event_filters_map: Dict[Type[DomainEvent], List[EventFilter]] = {}
         self._handler_factory = lambda cls: cls()
 
     def set_handler_factory(self, handler_factory: HandlerFactory):
@@ -27,16 +27,16 @@ class DomainEventDispatcher:
     def add_subscription(self, subscription: DomainEventSubscription):
         self._subscriptions.setdefault(subscription.event_filter, []).append(subscription)
         for event_type in subscription.event_filter:
-            event_filter = self._event_type_to_event_filter_map.setdefault(event_type, [])
-            if subscription.event_filter not in event_filter:
-                event_filter.append(subscription.event_filter)
+            event_filters = self._event_type_to_event_filters_map.setdefault(event_type, [])
+            if subscription.event_filter not in event_filters:
+                event_filters.append(subscription.event_filter)
 
     def dispatch(self, events: Iterable[DomainEvent]):
         filtered_events: Dict[EventFilter, List[DomainEvent]] = {}
 
         for event in events:
             event_type = type(event)
-            event_filters = self._event_type_to_event_filter_map.get(event_type, [])
+            event_filters = self._event_type_to_event_filters_map.get(event_type, [])
             for event_filter in event_filters:
                 filtered_events.setdefault(event_filter, []).append(event)
 

--- a/winter_ddd/domain_event_dispatcher.py
+++ b/winter_ddd/domain_event_dispatcher.py
@@ -1,5 +1,8 @@
 from typing import Callable
+from typing import Dict
 from typing import Iterable
+from typing import List
+from typing import Tuple
 from typing import Type
 from typing import TypeVar
 
@@ -9,11 +12,13 @@ from .domain_event_subscription import DomainEventSubscription
 T = TypeVar('T')
 HandlerFactory = Callable[[Type[T]], T]
 
+EventFilter = Tuple[Type[DomainEvent]]
+
 
 class DomainEventDispatcher:
     def __init__(self):
-        self._subscriptions = {}
-        self._event_type_to_event_filter_map = {}
+        self._subscriptions: Dict[EventFilter, List[DomainEventSubscription]] = {}
+        self._event_type_to_event_filter_map: Dict[Type[DomainEvent], List[EventFilter]] = {}
         self._handler_factory = lambda cls: cls()
 
     def set_handler_factory(self, handler_factory: HandlerFactory):
@@ -22,10 +27,12 @@ class DomainEventDispatcher:
     def add_subscription(self, subscription: DomainEventSubscription):
         self._subscriptions.setdefault(subscription.event_filter, []).append(subscription)
         for event_type in subscription.event_filter:
-            self._event_type_to_event_filter_map.setdefault(event_type, set()).add(subscription.event_filter)
+            event_filter = self._event_type_to_event_filter_map.setdefault(event_type, [])
+            if subscription.event_filter not in event_filter:
+                event_filter.append(subscription.event_filter)
 
     def dispatch(self, events: Iterable[DomainEvent]):
-        filtered_events = {}
+        filtered_events: Dict[EventFilter, List[DomainEvent]] = {}
 
         for event in events:
             event_type = type(event)


### PR DESCRIPTION
With the current implementation, we use set()  at DomainEventDispatcher, hence there is non-deterministic order of execution domain event’s handlers. It can lead to deadlock. 

For example, if we have 2 handlers on the domain event, which insert a row to the according tables, and if execution order between transactions is different, then there is a deadlock on insert statement: transaction 1 inserts to first table and waits for the lock at second table, and simultaneously transaction 2 inserts to second table and waits for lock at first table.

Set() has been replaced by List with "already exist" check.