### PR TITLE
Python39 compatibility

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Framework :: Django',
     'Framework :: Django :: 1.11',
     'Framework :: Django :: 2.0',

--- a/winter/core/json/decoder.py
+++ b/winter/core/json/decoder.py
@@ -277,7 +277,7 @@ def decode_dict(value, type_) -> dict:
         raise JSONDecodeException.cannot_decode(value=value, type_name='object')
     key_and_value_type = get_generic_args(type_)
 
-    if key_and_value_type is ():
+    if not key_and_value_type:
         return value
 
     key_type, value_type = key_and_value_type

--- a/winter/core/json/decoder.py
+++ b/winter/core/json/decoder.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import decimal
 import enum
@@ -15,9 +16,9 @@ from typing import Type
 from typing import TypeVar
 from typing import Union
 
-import dataclasses
 from dateutil import parser
 
+from winter.core.utils.typing import get_generic_args
 from winter.core.utils.typing import get_origin_type
 from winter.core.utils.typing import is_optional
 
@@ -274,13 +275,9 @@ def decode_tuple(value, type_) -> tuple:
 def decode_dict(value, type_) -> dict:
     if not isinstance(value, dict):
         raise JSONDecodeException.cannot_decode(value=value, type_name='object')
-    key_and_value_type = getattr(type_, '__args__', None)
+    key_and_value_type = get_generic_args(type_)
 
-    if key_and_value_type is None:
-        return value
-
-    # noinspection PyUnresolvedReferences
-    if key_and_value_type == (TypeVar, TypeVar):
+    if key_and_value_type is ():
         return value
 
     key_type, value_type = key_and_value_type

--- a/winter/core/json/decoder.py
+++ b/winter/core/json/decoder.py
@@ -280,7 +280,7 @@ def decode_dict(value, type_) -> dict:
         return value
 
     # noinspection PyUnresolvedReferences
-    if key_and_value_type == Dict.__args__:
+    if key_and_value_type == (TypeVar, TypeVar):
         return value
 
     key_type, value_type = key_and_value_type

--- a/winter/core/utils/typing.py
+++ b/winter/core/utils/typing.py
@@ -62,4 +62,4 @@ def get_generic_args(type_):
     if sys.version_info >= (3, 8):
         from typing import get_args
         return get_args(type_)
-    return getattr(type_, '__args__', ())
+    return getattr(type_, '__args__', None) or ()

--- a/winter/web/request_body_annotation.py
+++ b/winter/web/request_body_annotation.py
@@ -1,6 +1,10 @@
+from typing import List
+
 import dataclasses
 
 from winter.core import annotate_method
+
+ListType = type(List)
 
 
 @dataclasses.dataclass
@@ -10,7 +14,8 @@ class RequestBodyAnnotation:
 
 def check_request_body_type(argument_type):
     is_list = getattr(argument_type, '__origin__', None) is list
-    if not dataclasses.is_dataclass(argument_type) and not is_list:
+    is_typing_list = isinstance(argument_type, ListType)  # for py36 compatibility
+    if not dataclasses.is_dataclass(argument_type) and not is_list and not is_typing_list:
         raise AssertionError('Invalid request body type')
 
 

--- a/winter/web/request_body_annotation.py
+++ b/winter/web/request_body_annotation.py
@@ -1,10 +1,6 @@
-from typing import List
-
 import dataclasses
 
 from winter.core import annotate_method
-
-ListType = type(List)
 
 
 @dataclasses.dataclass
@@ -13,7 +9,8 @@ class RequestBodyAnnotation:
 
 
 def check_request_body_type(argument_type):
-    if not dataclasses.is_dataclass(argument_type) and not isinstance(argument_type, ListType):
+    is_list = getattr(argument_type, '__origin__', None) is list
+    if not dataclasses.is_dataclass(argument_type) and not is_list:
         raise AssertionError('Invalid request body type')
 
 

--- a/winter/web/request_body_annotation.py
+++ b/winter/web/request_body_annotation.py
@@ -3,6 +3,7 @@ from typing import List
 import dataclasses
 
 from winter.core import annotate_method
+from winter.core.utils.typing import NoneType
 
 ListType = type(List)
 
@@ -13,7 +14,7 @@ class RequestBodyAnnotation:
 
 
 def check_request_body_type(argument_type):
-    is_list = getattr(argument_type, '__origin__', None) is list
+    is_list = issubclass(getattr(argument_type, '__origin__', NoneType), list)
     is_typing_list = isinstance(argument_type, ListType)  # for py36 compatibility
     if not dataclasses.is_dataclass(argument_type) and not is_list and not is_typing_list:
         raise AssertionError('Invalid request body type')

--- a/winter/web/request_body_annotation.py
+++ b/winter/web/request_body_annotation.py
@@ -3,7 +3,7 @@ from typing import List
 import dataclasses
 
 from winter.core import annotate_method
-from winter.core.utils.typing import NoneType
+from winter.core.utils.typing import get_origin_type
 
 ListType = type(List)
 
@@ -14,9 +14,8 @@ class RequestBodyAnnotation:
 
 
 def check_request_body_type(argument_type):
-    is_list = issubclass(getattr(argument_type, '__origin__', NoneType), list)
-    is_typing_list = isinstance(argument_type, ListType)  # for py36 compatibility
-    if not dataclasses.is_dataclass(argument_type) and not is_list and not is_typing_list:
+    is_list = issubclass(get_origin_type(argument_type), list)
+    if not dataclasses.is_dataclass(argument_type) and not is_list:
         raise AssertionError('Invalid request body type')
 
 


### PR DESCRIPTION
use get_generic_args instead of `Type.__args__`
fix get_generic_args, cause in py36 `Dict.__args__` return None, not empty tuple