### PR TITLE
Fix cyclic imports caused by DRF importing external renderer classes during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.5.6] - 2022-06-16
+
+Fix cyclic imports caused by DRF importing external renderer classes during import
+
 ## [9.5.5] - 2022-06-13
 
 Generate titles for dataclass-generated openapi schemas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "9.5.5"
+version = "9.5.6"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/winter_django/view.py
+++ b/winter_django/view.py
@@ -3,11 +3,11 @@ from functools import wraps
 from typing import Any
 from typing import List
 from typing import Type
+from typing import TYPE_CHECKING
 
 import django.http
 import rest_framework.authentication
 import rest_framework.response
-import rest_framework.views
 from django.conf.urls import url
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -28,6 +28,10 @@ from winter.web.routing import Route
 from winter.web.routing import get_route
 from winter.web.throttling import create_throttle_class
 from winter.web.urls import rewrite_uritemplate_with_regexps
+
+
+if TYPE_CHECKING:
+    import rest_framework.views
 
 
 class SessionAuthentication(rest_framework.authentication.SessionAuthentication):
@@ -51,7 +55,9 @@ def create_django_urls(controller_class: Type) -> List:
     return django_urls
 
 
-def create_drf_view(controller_class: Type, routes: List[Route]) -> rest_framework.views.APIView:
+def create_drf_view(controller_class: Type, routes: List[Route]) -> 'rest_framework.views.APIView':
+    import rest_framework.views
+
     component = get_component(controller_class)
 
     class WinterView(rest_framework.views.APIView):


### PR DESCRIPTION
Also update version to 9.5.6