### PR TITLE
UUID query parameter newline character bug fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.6.1] - 2022-07-04
+
+Return 400 Bad Request instead of 500 if UUID request parameter has a newline character in the end
+
 ## [9.6.0] - 2022-06-22
 
 Return 400 Bad Request instead of 500 if UUID request parameter is malformed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "9.6.0"
+version = "9.6.1"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/winter/core/json/decoder.py
+++ b/winter/core/json/decoder.py
@@ -25,7 +25,7 @@ from winter.core.utils.typing import is_optional
 _decoders = {}
 
 Item = TypeVar('Item')
-uuid_regexp = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+uuid_regexp = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z')
 
 
 class _MissingException(Exception):


### PR DESCRIPTION
Return 400 Bad Request instead of 500 if UUID request parameter has a newline character in the end