### PR TITLE
Split sort method from paginate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "9.6.2"
+version = "9.6.3"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/tests/winter_sqlalchemy/test_sqla_sort.py
+++ b/tests/winter_sqlalchemy/test_sqla_sort.py
@@ -1,0 +1,36 @@
+import pytest
+from sqlalchemy import Column
+from sqlalchemy import Integer
+from sqlalchemy import MetaData
+from sqlalchemy import Table
+from sqlalchemy import create_engine
+from sqlalchemy import select
+
+from winter.data.pagination import Sort
+from winter_sqlalchemy import sort
+
+
+@pytest.mark.parametrize(
+    'sort_, expected_ids', [
+        (Sort.by('id'), [1, 2, 3]),
+        (Sort.by('id').desc(), [3, 2, 1]),
+    ],
+)
+def test_sort(id_database, sort_, expected_ids):
+    engine, table = id_database
+    statement = sort(select([table.c.id]), sort_)
+    result = engine.execute(statement)
+    ids = [row[0] for row in result]
+
+    assert ids == expected_ids
+
+
+@pytest.fixture(scope='module')
+def id_database():
+    engine = create_engine('sqlite://')
+    metadata = MetaData(engine)
+    table = Table('table', metadata, Column('id', Integer, primary_key=True))
+    metadata.create_all()
+    rows = [{'id': value} for value in range(1, 4)]
+    engine.execute(table.insert(), *rows)
+    return engine, table

--- a/winter_sqlalchemy/__init__.py
+++ b/winter_sqlalchemy/__init__.py
@@ -1,2 +1,3 @@
 from .query import paginate
+from .query import sort
 from .repository import sqla_crud

--- a/winter_sqlalchemy/query.py
+++ b/winter_sqlalchemy/query.py
@@ -3,6 +3,7 @@ from sqlalchemy import desc
 from sqlalchemy.sql import Select
 
 from winter.data.pagination import PagePosition
+from winter.data.pagination import Sort
 from winter.data.pagination import SortDirection
 
 _sort_direction_map = {
@@ -13,6 +14,10 @@ _sort_direction_map = {
 
 def paginate(select: Select, page_position: PagePosition) -> Select:
     if page_position.sort:
-        order_by_clauses = [_sort_direction_map[order.direction](order.field) for order in page_position.sort.orders]
-        select = select.order_by(*order_by_clauses)
+        select = sort(select, page_position.sort)
     return select.limit(page_position.limit).offset(page_position.offset)
+
+
+def sort(select: Select, sort: Sort) -> Select:
+    order_by_clauses = [_sort_direction_map[order.direction](order.field) for order in sort.orders]
+    return select.order_by(*order_by_clauses)


### PR DESCRIPTION
Split `sort` method from `paginate` so `order_by` can be applied separately from `limit` and `offset`