### PR TITLE
Register ThrottleException as a global to simplify projects without throttling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ dmypy.json
 
 # IDE
 .idea/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Register ThrottleException as a global to simplify projects without throttling
+
 ## [10.0.0]
 
 - Delete @winter.web.controller

--- a/winter_openapi/__init__.py
+++ b/winter_openapi/__init__.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from winter.data.pagination import Page
+from winter.web.exceptions import ThrottleException
 from winter.web.pagination.limits import MaximumLimitValueExceeded
 from .annotations import global_exception
 from .annotations import register_global_exception
@@ -24,6 +25,7 @@ def setup(allow_missing_raises_annotation: bool = False):
     from .page_inspector import inspect_page
 
     register_global_exception(MaximumLimitValueExceeded)
+    register_global_exception(ThrottleException)
     hinting_type_info.insert(0, (Enum, inspect_enum_class))
     register_type_inspector(Page, func=inspect_page)
     register_route_parameters_inspector(PathParametersInspector())


### PR DESCRIPTION
Before it was required to initialize winter_openapi that way:
`winter_openapi.setup(allow_missing_raises_annotation=True)`

Not it's possible to just call it with default parameters:
`winter_openapi.setup()`
