### PR TITLE
Follow RFC 7807 when responding with JSONDecodeException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [11.1.0]
+## [12.0.0]
 ### Changed
 - Adjust response body to comply with RFC7807 when request data decoding fails
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.1.0]
+### Changed
+- Adjust response body to comply with RFC7807 when request body json decoding fails
+
 ## [11.0.0]
 ### Added
 - get_all_subclasses function in module_discovery module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [11.1.0]
 ### Changed
-- Adjust response body to comply with RFC7807 when request body json decoding fails
+- Adjust response body to comply with RFC7807 when request data decoding fails
 
 ## [11.0.0]
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "11.0.0"
+version = "11.1.0"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "11.1.0"
+version = "12.0.0"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/tests/api/api_with_problem_exceptions.py
+++ b/tests/api/api_with_problem_exceptions.py
@@ -4,8 +4,8 @@ from typing import Dict
 import dataclasses
 
 import winter.web
-from winter.core.json import JSONDecodeException
 from winter.data.exceptions import NotFoundException
+from winter.web.exceptions import RequestDataDecodingException
 
 
 @winter.web.problem(status=HTTPStatus.FORBIDDEN)
@@ -89,7 +89,7 @@ class APIWithProblemExceptions:
     def not_found_exception(self) -> str:
         raise NotFoundException(entity_id=1, entity_cls=MyEntity)
 
-    @winter.route_get('json_decoder_errors_as_dict_exception/')
+    @winter.route_get('request_data_decoding_exception_with_dict_errors/')
     def json_decoder_errors_as_dict_exception(self) -> None:
         errors = {
             'non_field_error': 'Missing fields: "id", "status", "int_status", "birthday"',
@@ -97,9 +97,9 @@ class APIWithProblemExceptions:
                 'phones': 'Cannot decode "123" to set',
             },
         }
-        raise JSONDecodeException(errors)
+        raise RequestDataDecodingException(errors)
 
-    @winter.route_get('json_decoder_errors_as_str_exception/')
+    @winter.route_get('request_data_decoding_exception_with_str_errors/')
     def json_decoder_errors_as_str_exception(self) -> None:
         errors = 'Cannot decode "data1" to integer'
-        raise JSONDecodeException(errors)
+        raise RequestDataDecodingException(errors)

--- a/tests/api/api_with_problem_exceptions.py
+++ b/tests/api/api_with_problem_exceptions.py
@@ -5,7 +5,7 @@ import dataclasses
 
 import winter.web
 from winter.data.exceptions import NotFoundException
-from winter.web.exceptions import RequestDataDecodingException
+from winter.web.exceptions import RequestDataDecodeException
 
 
 @winter.web.problem(status=HTTPStatus.FORBIDDEN)
@@ -97,9 +97,9 @@ class APIWithProblemExceptions:
                 'phones': 'Cannot decode "123" to set',
             },
         }
-        raise RequestDataDecodingException(errors)
+        raise RequestDataDecodeException(errors)
 
     @winter.route_get('request_data_decoding_exception_with_str_errors/')
     def json_decoder_errors_as_str_exception(self) -> None:
         errors = 'Cannot decode "data1" to integer'
-        raise RequestDataDecodingException(errors)
+        raise RequestDataDecodeException(errors)

--- a/tests/api/api_with_problem_exceptions.py
+++ b/tests/api/api_with_problem_exceptions.py
@@ -4,6 +4,7 @@ from typing import Dict
 import dataclasses
 
 import winter.web
+from winter.core.json import JSONDecodeException
 from winter.data.exceptions import NotFoundException
 
 
@@ -87,3 +88,18 @@ class APIWithProblemExceptions:
     @winter.route_get('not_found_exception/')
     def not_found_exception(self) -> str:
         raise NotFoundException(entity_id=1, entity_cls=MyEntity)
+
+    @winter.route_get('json_decoder_errors_as_dict_exception/')
+    def json_decoder_errors_as_dict_exception(self) -> None:
+        errors = {
+            'non_field_error': 'Missing fields: "id", "status", "int_status", "birthday"',
+            'contact': {
+                'phones': 'Cannot decode "123" to set',
+            },
+        }
+        raise JSONDecodeException(errors)
+
+    @winter.route_get('json_decoder_errors_as_str_exception/')
+    def json_decoder_errors_as_str_exception(self) -> None:
+        errors = 'Cannot decode "data1" to integer'
+        raise JSONDecodeException(errors)

--- a/tests/pagination/test_page_position_argument_resolver.py
+++ b/tests/pagination/test_page_position_argument_resolver.py
@@ -9,7 +9,7 @@ from winter.core import ComponentMethod
 from winter.core.json import decoder
 from winter.data.pagination import PagePosition
 from winter.data.pagination import Sort
-from winter.web.exceptions import RequestDataDecodingException
+from winter.web.exceptions import RequestDataDecodeException
 from winter.web.pagination import PagePositionArgumentResolver
 
 
@@ -115,13 +115,13 @@ def test_resolve_argument_ok_in_page_position_argument_resolver_with_default(
     ('query_string', 'exception_type', 'message', 'errors_dict'), (
         (
             'limit=none',
-            RequestDataDecodingException,
+            RequestDataDecodeException,
             'Failed to decode request data',
             {'error': 'Cannot decode "none" to PositiveInteger'}
         ),
         (
             'offset=-20',
-            RequestDataDecodingException,
+            RequestDataDecodeException,
             'Failed to decode request data',
             {'error': 'Cannot decode "-20" to PositiveInteger'}
         ),

--- a/tests/routing/test_query_parameters.py
+++ b/tests/routing/test_query_parameters.py
@@ -15,7 +15,7 @@ from tests.entities import AuthorizedUser
 from tests.utils import get_request
 from winter.core.annotations import AlreadyAnnotated
 from winter.web.argument_resolver import ArgumentNotSupported
-from winter.web.exceptions import RequestDataDecodingException
+from winter.web.exceptions import RequestDataDecodeException
 from winter.web.query_parameters.query_parameters_argument_resolver import QueryParameterArgumentResolver
 
 
@@ -66,7 +66,7 @@ def test_query_parameter_resolver_with_raises_parse_error(query_string, expected
     argument = method.get_argument('query_param')
     request = get_request(query_string)
 
-    with pytest.raises(RequestDataDecodingException) as exception_info:
+    with pytest.raises(RequestDataDecodeException) as exception_info:
         resolver.resolve_argument(argument, request, {})
 
     assert str(exception_info.value) == expected_exception_message
@@ -83,7 +83,7 @@ def test_query_parameter_resolver_with_raises_parse_uuid_error():
     argument = method.get_argument('query_param')
     request = get_request('query_param=invalid_uuid')
 
-    with pytest.raises(RequestDataDecodingException) as exception_info:
+    with pytest.raises(RequestDataDecodeException) as exception_info:
         resolver.resolve_argument(argument, request, {})
 
     assert str(exception_info.value) == 'Failed to decode request data'
@@ -166,7 +166,7 @@ def test_orphan_map_query_parameter_fails():
     argument = method.get_argument('x_param')
     request = get_request('?x=1')
 
-    with pytest.raises(RequestDataDecodingException) as exception_info:
+    with pytest.raises(RequestDataDecodeException) as exception_info:
         resolver.resolve_argument(argument, request, {})
 
     assert str(exception_info.value) == 'Failed to decode request data'

--- a/tests/routing/test_query_parameters.py
+++ b/tests/routing/test_query_parameters.py
@@ -14,8 +14,8 @@ import winter
 from tests.entities import AuthorizedUser
 from tests.utils import get_request
 from winter.core.annotations import AlreadyAnnotated
-from winter.core.json import decoder
 from winter.web.argument_resolver import ArgumentNotSupported
+from winter.web.exceptions import RequestDataDecodingException
 from winter.web.query_parameters.query_parameters_argument_resolver import QueryParameterArgumentResolver
 
 
@@ -47,12 +47,16 @@ def test_query_parameter_resolver(argument_name, query_string, expected_value):
 
 
 @pytest.mark.parametrize(
-    ('query_string', 'expected_exception_message'), (
-        ('query_param=invalid_int', 'Cannot decode "invalid_int" to integer'),
-        ('', 'Missing required query parameter "query_param"'),
+    ('query_string', 'expected_exception_message', 'expected_errors'), (
+        (
+            'query_param=invalid_int',
+            'Failed to decode request data',
+            {'error': 'Cannot decode "invalid_int" to integer'}
+        ),
+        ('', 'Failed to decode request data', {'error': 'Missing required query parameter "query_param"'}),
     ),
 )
-def test_query_parameter_resolver_with_raises_parse_error(query_string, expected_exception_message):
+def test_query_parameter_resolver_with_raises_parse_error(query_string, expected_exception_message, expected_errors):
     @winter.route_get('{?query_param}')
     def method(query_param: int):  # pragma: no cover
         return query_param
@@ -62,10 +66,11 @@ def test_query_parameter_resolver_with_raises_parse_error(query_string, expected
     argument = method.get_argument('query_param')
     request = get_request(query_string)
 
-    with pytest.raises(decoder.JSONDecodeException) as exception:
+    with pytest.raises(RequestDataDecodingException) as exception_info:
         resolver.resolve_argument(argument, request, {})
 
-    assert str(exception.value) == expected_exception_message
+    assert str(exception_info.value) == expected_exception_message
+    assert exception_info.value.errors == expected_errors
 
 
 def test_query_parameter_resolver_with_raises_parse_uuid_error():
@@ -78,10 +83,11 @@ def test_query_parameter_resolver_with_raises_parse_uuid_error():
     argument = method.get_argument('query_param')
     request = get_request('query_param=invalid_uuid')
 
-    with pytest.raises(decoder.JSONDecodeException) as exception:
+    with pytest.raises(RequestDataDecodingException) as exception_info:
         resolver.resolve_argument(argument, request, {})
 
-    assert str(exception.value) == 'Cannot decode "invalid_uuid" to uuid'
+    assert str(exception_info.value) == 'Failed to decode request data'
+    assert exception_info.value.errors == {'error': 'Cannot decode "invalid_uuid" to uuid'}
 
 
 @pytest.mark.parametrize(
@@ -160,10 +166,11 @@ def test_orphan_map_query_parameter_fails():
     argument = method.get_argument('x_param')
     request = get_request('?x=1')
 
-    with pytest.raises(decoder.JSONDecodeException) as exception:
+    with pytest.raises(RequestDataDecodingException) as exception_info:
         resolver.resolve_argument(argument, request, {})
 
-    assert str(exception.value) == 'Missing required query parameter "x"'
+    assert str(exception_info.value) == 'Failed to decode request data'
+    assert exception_info.value.errors == {'error': 'Missing required query parameter "x"'}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -123,6 +123,34 @@ def test_exception_handler_with_unknown_argument():
                 'detail': 'MyEntity with ID=1 not found',
             },
         ),
+        (
+            'json_decoder_errors_as_str_exception',
+            HTTPStatus.BAD_REQUEST,
+            'application/json+problem',
+            {
+                'status': 400,
+                'type': 'urn:problem-type:json-decode-error',
+                'title': 'Json decode error',
+                'detail': 'Cannot decode "data1" to integer',
+            },
+        ),
+        (
+            'json_decoder_errors_as_dict_exception',
+            HTTPStatus.BAD_REQUEST,
+            'application/json+problem',
+            {
+                'status': 400,
+                'type': 'urn:problem-type:json-decode-error',
+                'title': 'Json decode error',
+                'detail': 'Failed to decode json',
+                'errors': {
+                    'non_field_error': 'Missing fields: "id", "status", "int_status", "birthday"',
+                    'contact': {
+                        'phones': 'Cannot decode "123" to set',
+                    },
+                }
+            },
+        ),
     ),
 )
 def test_api_with_problem_exceptions(url_path, expected_status, expected_content_type, expected_body):

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -124,25 +124,26 @@ def test_exception_handler_with_unknown_argument():
             },
         ),
         (
-            'json_decoder_errors_as_str_exception',
+            'request_data_decoding_exception_with_str_errors',
             HTTPStatus.BAD_REQUEST,
             'application/json+problem',
             {
                 'status': 400,
-                'type': 'urn:problem-type:json-decode-error',
-                'title': 'Json decode error',
-                'detail': 'Cannot decode "data1" to integer',
+                'type': 'urn:problem-type:request-data-decoding',
+                'title': 'Request data decoding',
+                'detail': 'Failed to decode request data',
+                'errors': {'error': 'Cannot decode "data1" to integer'},
             },
         ),
         (
-            'json_decoder_errors_as_dict_exception',
+            'request_data_decoding_exception_with_dict_errors',
             HTTPStatus.BAD_REQUEST,
             'application/json+problem',
             {
                 'status': 400,
-                'type': 'urn:problem-type:json-decode-error',
-                'title': 'Json decode error',
-                'detail': 'Failed to decode json',
+                'type': 'urn:problem-type:request-data-decoding',
+                'title': 'Request data decoding',
+                'detail': 'Failed to decode request data',
                 'errors': {
                     'non_field_error': 'Missing fields: "id", "status", "int_status", "birthday"',
                     'contact': {

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -129,8 +129,8 @@ def test_exception_handler_with_unknown_argument():
             'application/json+problem',
             {
                 'status': 400,
-                'type': 'urn:problem-type:request-data-decoding',
-                'title': 'Request data decoding',
+                'type': 'urn:problem-type:request-data-decode',
+                'title': 'Request data decode',
                 'detail': 'Failed to decode request data',
                 'errors': {'error': 'Cannot decode "data1" to integer'},
             },
@@ -141,8 +141,8 @@ def test_exception_handler_with_unknown_argument():
             'application/json+problem',
             {
                 'status': 400,
-                'type': 'urn:problem-type:request-data-decoding',
-                'title': 'Request data decoding',
+                'type': 'urn:problem-type:request-data-decode',
+                'title': 'Request data decode',
                 'detail': 'Failed to decode request data',
                 'errors': {
                     'non_field_error': 'Missing fields: "id", "status", "int_status", "birthday"',

--- a/tests/web/test_request_body.py
+++ b/tests/web/test_request_body.py
@@ -85,8 +85,8 @@ def test_request_body_with_errors():
 
     expected_data = {
         'status': 400,
-        'type': 'urn:problem-type:request-data-decoding',
-        'title': 'Request data decoding',
+        'type': 'urn:problem-type:request-data-decode',
+        'title': 'Request data decode',
         'detail': 'Failed to decode request data',
         'errors': {
             'id': 'Cannot decode "invalid integer" to integer',

--- a/tests/web/test_request_body.py
+++ b/tests/web/test_request_body.py
@@ -85,9 +85,9 @@ def test_request_body_with_errors():
 
     expected_data = {
         'status': 400,
-        'type': 'urn:problem-type:json-decode-error',
-        'title': 'Json decode error',
-        'detail': 'Failed to decode json',
+        'type': 'urn:problem-type:request-data-decoding',
+        'title': 'Request data decoding',
+        'detail': 'Failed to decode request data',
         'errors': {
             'id': 'Cannot decode "invalid integer" to integer',
             'status': 'Value not in allowed values("active", "super_active"): "invalid status"',

--- a/tests/web/test_request_body.py
+++ b/tests/web/test_request_body.py
@@ -84,10 +84,16 @@ def test_request_body_with_errors():
     }
 
     expected_data = {
-        'id': 'Cannot decode "invalid integer" to integer',
-        'status': 'Value not in allowed values("active", "super_active"): "invalid status"',
-        'items': 'Cannot decode "invalid integer" to integer',
-        'non_field_error': 'Missing fields: "name"',
+        'status': 400,
+        'type': 'urn:problem-type:json-decode-error',
+        'title': 'Json decode error',
+        'detail': 'Failed to decode json',
+        'errors': {
+            'id': 'Cannot decode "invalid integer" to integer',
+            'status': 'Value not in allowed values("active", "super_active"): "invalid status"',
+            'items': 'Cannot decode "invalid integer" to integer',
+            'non_field_error': 'Missing fields: "name"',
+        }
     }
     data = json.dumps(data)
 

--- a/winter/web/__init__.py
+++ b/winter/web/__init__.py
@@ -23,15 +23,12 @@ from .urls import register_url_regexp
 
 
 def setup():
-    from http import HTTPStatus
-    from winter.core.json.decoder import JSONDecodeException
     from winter.data.exceptions import NotFoundException
     from .configurer import run_configurers
     from .exceptions import RedirectException
     from .exceptions.problem_handling import autodiscover_problem_annotations
     from .exceptions.problem_handling import ProblemExceptionHandlerGenerator
     from .exceptions.problem_handling import ProblemExceptionMapper
-    from .exceptions.problem_handling import JsonDecodeProblemExceptionMapper
     from .exceptions.problem_handling_info import ProblemHandlingInfo
     from .exception_handlers import RedirectExceptionHandler
     from .pagination.page_processor_resolver import PageOutputProcessorResolver
@@ -53,12 +50,7 @@ def setup():
     exception_mapper = ProblemExceptionMapper()
     exception_handler_generator = ProblemExceptionHandlerGenerator(exception_mapper)
     autodiscover_problem_annotations(exception_handler_generator)
-    json_decode_exception_handler_generator = ProblemExceptionHandlerGenerator(JsonDecodeProblemExceptionMapper())
     auto_handle_exceptions = {
-        JSONDecodeException: json_decode_exception_handler_generator.generate(
-            JSONDecodeException,
-            ProblemHandlingInfo(status=HTTPStatus.BAD_REQUEST)
-        ),
         RedirectException: RedirectExceptionHandler,
         NotFoundException: exception_handler_generator.generate(NotFoundException, ProblemHandlingInfo(status=404)),
     }

--- a/winter/web/exception_handlers.py
+++ b/winter/web/exception_handlers.py
@@ -1,18 +1,10 @@
 from http import HTTPStatus
-from typing import Dict
 
-from winter.core.json.decoder import JSONDecodeException
 from .exceptions import ExceptionHandler
 from .exceptions import RedirectException
 from .response_header_annotation import ResponseHeader
 from .response_header_annotation import response_header
 from .response_status_annotation import response_status
-
-
-class DecodeExceptionHandler(ExceptionHandler):
-    @response_status(HTTPStatus.BAD_REQUEST)
-    def handle(self, exception: JSONDecodeException) -> Dict:
-        return exception.errors
 
 
 class RedirectExceptionHandler(ExceptionHandler):

--- a/winter/web/exceptions/__init__.py
+++ b/winter/web/exceptions/__init__.py
@@ -2,7 +2,7 @@ from .exception_handler_generator import ExceptionHandlerGenerator
 from .exception_mapper import ExceptionMapper
 from .exceptions import RedirectException
 from .exceptions import ThrottleException
-from .exceptions import RequestDataDecodingException
+from .exceptions import RequestDataDecodeException
 from .handlers import ExceptionHandler
 from .handlers import MethodExceptionsManager
 from .handlers import exception_handlers_registry

--- a/winter/web/exceptions/__init__.py
+++ b/winter/web/exceptions/__init__.py
@@ -2,6 +2,7 @@ from .exception_handler_generator import ExceptionHandlerGenerator
 from .exception_mapper import ExceptionMapper
 from .exceptions import RedirectException
 from .exceptions import ThrottleException
+from .exceptions import RequestDataDecodingException
 from .handlers import ExceptionHandler
 from .handlers import MethodExceptionsManager
 from .handlers import exception_handlers_registry

--- a/winter/web/exceptions/exceptions.py
+++ b/winter/web/exceptions/exceptions.py
@@ -1,4 +1,9 @@
 from http import HTTPStatus
+from typing import Dict
+from typing import Optional
+from typing import Union
+
+import dataclasses
 
 from .problem import problem
 
@@ -12,3 +17,16 @@ class RedirectException(Exception):
     def __init__(self, redirect_to: str):
         super().__init__()
         self.redirect_to = redirect_to
+
+
+@problem(status=HTTPStatus.BAD_REQUEST)
+@dataclasses.dataclass
+class RequestDataDecodingException(Exception):
+    errors: dict = dataclasses.field(default_factory=dict)
+
+    def __init__(self, errors: Optional[Union[str, Dict]]):
+        super().__init__('Failed to decode request data')
+        if type(errors) == dict:
+            self.errors = errors
+        elif type(errors) == str:
+            self.errors = {'error': errors}

--- a/winter/web/exceptions/exceptions.py
+++ b/winter/web/exceptions/exceptions.py
@@ -21,7 +21,7 @@ class RedirectException(Exception):
 
 @problem(status=HTTPStatus.BAD_REQUEST)
 @dataclasses.dataclass
-class RequestDataDecodingException(Exception):
+class RequestDataDecodeException(Exception):
     errors: dict = dataclasses.field(default_factory=dict)
 
     def __init__(self, errors: Optional[Union[str, Dict]]):

--- a/winter/web/exceptions/problem_handling.py
+++ b/winter/web/exceptions/problem_handling.py
@@ -1,12 +1,11 @@
-import re
-from http import HTTPStatus
-from typing import Dict
-from typing import Type
-
 import dataclasses
+import re
 from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import is_dataclass
+from typing import Dict
+from typing import Type
+
 from rest_framework.request import Request
 
 from winter.core import Component
@@ -19,7 +18,6 @@ from .handlers import exception_handlers_registry
 from .problem_annotation import ProblemAnnotation
 from .problem_handling_info import ProblemHandlingInfo
 from ... import response_header
-from ...core.json import JSONDecodeException
 
 
 class ProblemExceptionHandlerGenerator(ExceptionHandlerGenerator):
@@ -92,29 +90,6 @@ class ProblemExceptionMapper(ExceptionMapper):
     @classmethod
     def _try_cut_exception_name_postfix(cls, exception_cls: Type[Exception]) -> str:
         return re.sub('Exception$', '', exception_cls.__name__)
-
-
-class JsonDecodeProblemExceptionMapper(ProblemExceptionMapper):
-    def to_response_body(
-        self,
-        request: Request,
-        exception: JSONDecodeException,
-        handling_info: ProblemHandlingInfo
-    ) -> Dict:
-        problem_handling_info = ProblemHandlingInfo(
-            status=handling_info.status or HTTPStatus.BAD_REQUEST,
-            title=handling_info.title or 'Json decode error',
-            type=handling_info.type or 'urn:problem-type:json-decode-error',
-            detail=handling_info.detail or (
-                exception.errors if type(exception.errors) == str else 'Failed to decode json'
-            ),
-        )
-
-        problem_dict = super().to_response_body(request, exception, problem_handling_info)
-        if exception.errors and not type(exception.errors) == str:
-            problem_dict['errors'] = exception.errors
-
-        return problem_dict
 
 
 def autodiscover_problem_annotations(handler_generator: ProblemExceptionHandlerGenerator):

--- a/winter/web/exceptions/problem_handling.py
+++ b/winter/web/exceptions/problem_handling.py
@@ -1,4 +1,5 @@
 import re
+from http import HTTPStatus
 from typing import Dict
 from typing import Type
 
@@ -18,6 +19,7 @@ from .handlers import exception_handlers_registry
 from .problem_annotation import ProblemAnnotation
 from .problem_handling_info import ProblemHandlingInfo
 from ... import response_header
+from ...core.json import JSONDecodeException
 
 
 class ProblemExceptionHandlerGenerator(ExceptionHandlerGenerator):
@@ -90,6 +92,29 @@ class ProblemExceptionMapper(ExceptionMapper):
     @classmethod
     def _try_cut_exception_name_postfix(cls, exception_cls: Type[Exception]) -> str:
         return re.sub('Exception$', '', exception_cls.__name__)
+
+
+class JsonDecodeProblemExceptionMapper(ProblemExceptionMapper):
+    def to_response_body(
+        self,
+        request: Request,
+        exception: JSONDecodeException,
+        handling_info: ProblemHandlingInfo
+    ) -> Dict:
+        problem_handling_info = ProblemHandlingInfo(
+            status=handling_info.status or HTTPStatus.BAD_REQUEST,
+            title=handling_info.title or 'Json decode error',
+            type=handling_info.type or 'urn:problem-type:json-decode-error',
+            detail=handling_info.detail or (
+                exception.errors if type(exception.errors) == str else 'Failed to decode json'
+            ),
+        )
+
+        problem_dict = super().to_response_body(request, exception, problem_handling_info)
+        if exception.errors and not type(exception.errors) == str:
+            problem_dict['errors'] = exception.errors
+
+        return problem_dict
 
 
 def autodiscover_problem_annotations(handler_generator: ProblemExceptionHandlerGenerator):

--- a/winter/web/pagination/page_position_argument_resolver.py
+++ b/winter/web/pagination/page_position_argument_resolver.py
@@ -13,7 +13,7 @@ from winter.data.pagination import PagePosition
 from winter.data.pagination import Sort
 from winter.web.argument_resolver import ArgumentResolver
 from winter.web.exceptions import RedirectException
-from winter.web.exceptions import RequestDataDecodingException
+from winter.web.exceptions import RequestDataDecodeException
 from winter.web.pagination.check_sort import check_sort
 from winter.web.pagination.limits import Limits
 from winter.web.pagination.limits import LimitsAnnotation
@@ -80,7 +80,7 @@ class PagePositionArgumentResolver(ArgumentResolver):
             limit = json_decode(raw_limit, Optional[PositiveInteger])
             offset = json_decode(raw_offset, Optional[PositiveInteger])
         except JSONDecodeException as e:
-            raise RequestDataDecodingException(e.errors)
+            raise RequestDataDecodeException(e.errors)
         sort = self._parse_sort_properties(raw_order_by, argument)
         return PagePosition(limit=limit, offset=offset, sort=sort)
 

--- a/winter/web/pagination/page_position_argument_resolver.py
+++ b/winter/web/pagination/page_position_argument_resolver.py
@@ -6,12 +6,14 @@ from rest_framework.request import Request
 
 from winter.core import ComponentMethod
 from winter.core import ComponentMethodArgument
+from winter.core.json import JSONDecodeException
 from winter.core.json import json_decode
 from winter.core.utils import PositiveInteger
 from winter.data.pagination import PagePosition
 from winter.data.pagination import Sort
 from winter.web.argument_resolver import ArgumentResolver
 from winter.web.exceptions import RedirectException
+from winter.web.exceptions import RequestDataDecodingException
 from winter.web.pagination.check_sort import check_sort
 from winter.web.pagination.limits import Limits
 from winter.web.pagination.limits import LimitsAnnotation
@@ -74,8 +76,11 @@ class PagePositionArgumentResolver(ArgumentResolver):
         raw_limit = http_request.query_params.get(self.limit_name) or None
         raw_offset = http_request.query_params.get(self.offset_name) or None
         raw_order_by = http_request.query_params.get(self.order_by_name, '')
-        limit = json_decode(raw_limit, Optional[PositiveInteger])
-        offset = json_decode(raw_offset, Optional[PositiveInteger])
+        try:
+            limit = json_decode(raw_limit, Optional[PositiveInteger])
+            offset = json_decode(raw_offset, Optional[PositiveInteger])
+        except JSONDecodeException as e:
+            raise RequestDataDecodingException(e.errors)
         sort = self._parse_sort_properties(raw_order_by, argument)
         return PagePosition(limit=limit, offset=offset, sort=sort)
 

--- a/winter/web/query_parameters/query_parameters_argument_resolver.py
+++ b/winter/web/query_parameters/query_parameters_argument_resolver.py
@@ -11,7 +11,7 @@ from winter.core.utils.typing import is_iterable_type
 from .query_parameter import QueryParameter
 from ..argument_resolver import ArgumentNotSupported
 from ..argument_resolver import ArgumentResolver
-from ..exceptions import RequestDataDecodingException
+from ..exceptions import RequestDataDecodeException
 from ..routing import get_route
 
 
@@ -45,14 +45,14 @@ class QueryParameterArgumentResolver(ArgumentResolver):
             try:
                 return argument.get_default()
             except ArgumentDoesNotHaveDefault:
-                raise RequestDataDecodingException(f'Missing required query parameter "{parameter_name}"')
+                raise RequestDataDecodeException(f'Missing required query parameter "{parameter_name}"')
 
         value = self._get_value(query_parameters, parameter_name, is_iterable, explode)
 
         try:
             return json_decode(value, argument.type_)
         except JSONDecodeException as e:
-            raise RequestDataDecodingException(e.errors)
+            raise RequestDataDecodeException(e.errors)
 
     def _get_query_parameter(self, argument: ComponentMethodArgument) -> Optional[QueryParameter]:
         if argument in self._query_parameters:

--- a/winter/web/query_parameters/query_parameters_argument_resolver.py
+++ b/winter/web/query_parameters/query_parameters_argument_resolver.py
@@ -11,6 +11,7 @@ from winter.core.utils.typing import is_iterable_type
 from .query_parameter import QueryParameter
 from ..argument_resolver import ArgumentNotSupported
 from ..argument_resolver import ArgumentResolver
+from ..exceptions import RequestDataDecodingException
 from ..routing import get_route
 
 
@@ -44,10 +45,14 @@ class QueryParameterArgumentResolver(ArgumentResolver):
             try:
                 return argument.get_default()
             except ArgumentDoesNotHaveDefault:
-                raise JSONDecodeException(f'Missing required query parameter "{parameter_name}"')
+                raise RequestDataDecodingException(f'Missing required query parameter "{parameter_name}"')
 
         value = self._get_value(query_parameters, parameter_name, is_iterable, explode)
-        return json_decode(value, argument.type_)
+
+        try:
+            return json_decode(value, argument.type_)
+        except JSONDecodeException as e:
+            raise RequestDataDecodingException(e.errors)
 
     def _get_query_parameter(self, argument: ComponentMethodArgument) -> Optional[QueryParameter]:
         if argument in self._query_parameters:

--- a/winter/web/request_body_resolver.py
+++ b/winter/web/request_body_resolver.py
@@ -3,8 +3,10 @@ from typing import MutableMapping
 from rest_framework.request import Request
 
 from .argument_resolver import ArgumentResolver
+from .exceptions.exceptions import RequestDataDecodingException
 from .request_body_annotation import RequestBodyAnnotation
 from ..core import ComponentMethodArgument
+from ..core.json import JSONDecodeException
 from ..core.json import json_decode
 
 
@@ -22,4 +24,7 @@ class RequestBodyArgumentResolver(ArgumentResolver):
         request: Request,
         response_headers: MutableMapping[str, str],
     ):
-        return json_decode(request.data, argument.type_)
+        try:
+            return json_decode(request.data, argument.type_)
+        except JSONDecodeException as e:
+            raise RequestDataDecodingException(e.errors)

--- a/winter/web/request_body_resolver.py
+++ b/winter/web/request_body_resolver.py
@@ -3,7 +3,7 @@ from typing import MutableMapping
 from rest_framework.request import Request
 
 from .argument_resolver import ArgumentResolver
-from .exceptions.exceptions import RequestDataDecodingException
+from .exceptions.exceptions import RequestDataDecodeException
 from .request_body_annotation import RequestBodyAnnotation
 from ..core import ComponentMethodArgument
 from ..core.json import JSONDecodeException
@@ -27,4 +27,4 @@ class RequestBodyArgumentResolver(ArgumentResolver):
         try:
             return json_decode(request.data, argument.type_)
         except JSONDecodeException as e:
-            raise RequestDataDecodingException(e.errors)
+            raise RequestDataDecodeException(e.errors)

--- a/winter_openapi/__init__.py
+++ b/winter_openapi/__init__.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from winter.data.pagination import Page
-from winter.web.exceptions import RequestDataDecodingException
+from winter.web.exceptions import RequestDataDecodeException
 from winter.web.exceptions import ThrottleException
 from winter.web.pagination.limits import MaximumLimitValueExceeded
 from .annotations import global_exception
@@ -28,7 +28,7 @@ def setup(allow_missing_raises_annotation: bool = False):
 
     register_global_exception(MaximumLimitValueExceeded)
     register_global_exception(ThrottleException)
-    register_global_exception(RequestDataDecodingException)
+    register_global_exception(RequestDataDecodeException)
     hinting_type_info.insert(0, (Enum, inspect_enum_class))
     register_type_inspector(Page, func=inspect_page)
     register_route_parameters_inspector(PathParametersInspector())

--- a/winter_openapi/__init__.py
+++ b/winter_openapi/__init__.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from winter.data.pagination import Page
+from winter.web.exceptions import RequestDataDecodingException
 from winter.web.exceptions import ThrottleException
 from winter.web.pagination.limits import MaximumLimitValueExceeded
 from .annotations import global_exception
@@ -27,6 +28,7 @@ def setup(allow_missing_raises_annotation: bool = False):
 
     register_global_exception(MaximumLimitValueExceeded)
     register_global_exception(ThrottleException)
+    register_global_exception(RequestDataDecodingException)
     hinting_type_info.insert(0, (Enum, inspect_enum_class))
     register_type_inspector(Page, func=inspect_page)
     register_route_parameters_inspector(PathParametersInspector())


### PR DESCRIPTION
https://supplyshift.atlassian.net/browse/SUSHI-10300

**Main changes:**
- **JSONDecodeException**s thrown while decoding request data (body json, get attributes) are now caught and re-thrown as _@web.problem_ annotated **RequestDataDecodingException** to comply with **RFC7807**
- **DecodeExceptionHandler** is removed - uncaught JSONDecodeExceptions will be eventually responded as http 500