### PR TITLE
Fixed generation of the default parameter for `order_by` OpenAPI descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [15.0.1] - 2023-01-28
-### Bugfixes
-- Fixed generation of the default parameter for `order_by` OpenAPI descriptions
-
-## [15.0.0] - 2023-01-28
+## [15.0.0] - 2023-02-01
 ### Changed
 - winter.messaging: EventBus interface segregated and renamed to EventPublisher
+### Bugfixes
+- Fixed generation of the default parameter for `order_by` OpenAPI descriptions
 
 ## [14.1.0] - 2022-12-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.0.1] - 2023-01-28
+### Bugfixes
+- Fixed generation of the default parameter for `order_by` OpenAPI descriptions
+
 ## [15.0.0] - 2023-01-28
 ### Changed
 - winter.messaging: EventBus interface segregated and renamed to EventPublisher

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "15.0.1"
+version = "15.0.0"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "15.0.0"
+version = "15.0.1"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/tests/pagination/test_page_position_argument_inspector.py
+++ b/tests/pagination/test_page_position_argument_inspector.py
@@ -38,7 +38,7 @@ def test_page_position_argument_inspector(argument_type, must_return_parameters)
     assert parameters == expected_parameters
 
 
-@pytest.mark.parametrize(('default_sort', 'default_in_parameter'), ((None, None), (('id',), 'id')))
+@pytest.mark.parametrize(('default_sort', 'default_in_parameter'), ((None, None), (('id',), ['id'])))
 def test_page_position_argument_inspector_with_allowed_order_by_fields(default_sort, default_in_parameter):
 
     class TestAPI:

--- a/winter_openapi/page_position_argument_inspector.py
+++ b/winter_openapi/page_position_argument_inspector.py
@@ -40,7 +40,7 @@ class PagePositionArgumentsInspector(RouteParametersInspector):
         if order_by_annotation:
             allowed_order_by_fields = ','.join(map(str, order_by_annotation.allowed_fields))
             default_sort = (
-                str(order_by_annotation.default_sort)
+                [str(order_by_annotation.default_sort)]
                 if order_by_annotation.default_sort is not None else
                 None
             )


### PR DESCRIPTION
Fix to get rid of `-attribute paths.'/organization/sites/'(get).[order_by].default is not of type array` warnings during client generation.