### PR TITLE
Fix error with cannot inherit frozen dataclass from a non-frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [15.2.1] - 2023-02-16
+### Changed
+- winter.messaging: set frozen=true for Event class
+
 ## [15.2.0] - 2023-02-15
 ### Added
 - winter.web.throttling: function allows to reset the accumulated throttling state for a specific user and scope

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "15.2.0"
+version = "15.2.1"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/tests/messaging/events.py
+++ b/tests/messaging/events.py
@@ -3,16 +3,16 @@ from dataclasses import dataclass
 from winter.messaging import Event
 
 
-@dataclass
+@dataclass(frozen=True)
 class Event1(Event):
     x: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class Event2(Event):
     x: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class Event3(Event):
     x: int

--- a/winter/messaging/event.py
+++ b/winter/messaging/event.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class Event:
     pass


### PR DESCRIPTION
Make Event class more strict by setting frozen true