### PR TITLE
Fix different models under the same names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [16.0.0] - 2023-04-04
+### Changed
+- Duplicate model names for different models don't appear in OpenAPI schema anymore - `PageMeta` renamed to `PageMetaOf{PageName}`, models in input parameters now have the suffix `Input`  
+
 ## [15.2.2] - 2023-02-23
 ### Added
 - winter_django.create_django_urls_from_routes: function that returns a list of django urls by the list of Routes 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "15.2.1"
+version = "16.0.0"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework inspired by Spring Framework"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/tests/winter_openapi/test_swagger_auto_schema.py
+++ b/tests/winter_openapi/test_swagger_auto_schema.py
@@ -90,7 +90,7 @@ class TestAPI:
 
 
 user_dto_request_schema = openapi.Schema(
-    title='UserDTO',
+    title='UserDTOInput',
     description='This is a short one line description.\n'
                 '\n'
                 'This is a long multi-line description.\n'
@@ -100,7 +100,7 @@ user_dto_request_schema = openapi.Schema(
         'name': openapi.Schema(type=openapi.TYPE_STRING, description='user name'),
         'nested_dto': {
             'type': openapi.TYPE_OBJECT,
-            'title': 'NestedDTO',
+            'title': 'NestedDTOInput',
             'description': 'a nested dto object.\n'
                            'It contains some extra data.',
 

--- a/tests/winter_openapi/test_type_inspection.py
+++ b/tests/winter_openapi/test_type_inspection.py
@@ -117,7 +117,7 @@ class CustomPage(Page, Generic[CustomPageItem]):
         })),
     (Page[NestedDataclass], TypeInfo(openapi.TYPE_OBJECT, title='PageOfNestedDataclass', properties={
         'meta': TypeInfo(openapi.TYPE_OBJECT,
-                         title='PageMeta',
+                         title='PageMetaOfNestedDataclass',
                          properties={
                              'total_count': TypeInfo(openapi.TYPE_INTEGER),
                              'limit': TypeInfo(openapi.TYPE_INTEGER, nullable=True),
@@ -132,7 +132,7 @@ class CustomPage(Page, Generic[CustomPageItem]):
                                            properties={'nested_number': TypeInfo(openapi.TYPE_INTEGER), })),
     })),
     (CustomPage[int], TypeInfo(openapi.TYPE_OBJECT, title='PageOfInteger', properties={
-        'meta': TypeInfo(openapi.TYPE_OBJECT, title='PageMeta', properties={
+        'meta': TypeInfo(openapi.TYPE_OBJECT, title='PageMetaOfInteger', properties={
             'total_count': TypeInfo(openapi.TYPE_INTEGER),
             'limit': TypeInfo(openapi.TYPE_INTEGER, nullable=True),
             'offset': TypeInfo(openapi.TYPE_INTEGER, nullable=True),

--- a/winter_openapi/page_inspector.py
+++ b/winter_openapi/page_inspector.py
@@ -13,14 +13,15 @@ def inspect_page(hint_class) -> TypeInfo:
     child_class = args[0] if args else str
     extra_fields = set(dataclasses.fields(hint_class.__origin__)) - set(dataclasses.fields(Page))
     child_type_info = inspect_type(child_class)
+    title = child_type_info.title or child_type_info.type_.capitalize()
 
     return TypeInfo(
         openapi.TYPE_OBJECT,
-        title=f'PageOf{child_type_info.title or child_type_info.type_.capitalize()}',
+        title=f'PageOf{title}',
         properties={
             'meta': TypeInfo(
                 openapi.TYPE_OBJECT,
-                title='PageMeta',
+                title=f'PageMetaOf{title}',
                 properties={
                     'total_count': TypeInfo(openapi.TYPE_INTEGER),
                     'limit': TypeInfo(openapi.TYPE_INTEGER, nullable=True),

--- a/winter_openapi/type_inspection.py
+++ b/winter_openapi/type_inspection.py
@@ -77,7 +77,10 @@ class TypeInfo:
         }
 
         if self.title:
-            data['title'] = self.title
+            if output:
+                data['title'] = self.title
+            else:
+                data['title'] = f'{self.title}Input'
 
         if self.description:
             data['description'] = self.description


### PR DESCRIPTION
Duplicate model names for different models don't appear in OpenAPI schema anymore - `PageMeta` renamed to `PageMetaOf{PageName}`, models in input parameters now have the suffix `Input`