### PR TITLE
Add url_path_tag to openapi operation tags. Use path without prefix with leading / as url path in specification

### DIFF
--- a/tests/winter_openapi/test_api_request_and_response_spec.py
+++ b/tests/winter_openapi/test_api_request_and_response_spec.py
@@ -283,7 +283,7 @@ def test_response_return_type(type_hint, expected_response_info):
                 'description': '',
             },
         },
-        'tags': [],
+        'tags': ['types'],
 
     }
     # Act

--- a/tests/winter_openapi/test_api_with_media_types_spec.py
+++ b/tests/winter_openapi/test_api_with_media_types_spec.py
@@ -31,7 +31,7 @@ def test_generate_spec_for_media_type_produces():
                         'description': '',
                     },
                 },
-                'tags': [],
+                'tags': ['xml'],
             },
         },
     }
@@ -76,7 +76,7 @@ def test_generate_spec_for_media_type_consumes():
                     'required': False,
                 },
                 'responses': {'200': {'description': ''}},
-                'tags': [],
+                'tags': ['xml'],
             },
         },
     }

--- a/tests/winter_openapi/test_exception_spec.py
+++ b/tests/winter_openapi/test_exception_spec.py
@@ -39,7 +39,7 @@ def test_global_exception_annotated_on_method():
                     'operationId': '_TestAPI.get_resource',
                     'parameters': [],
                     'responses': {'200': {'description': ''}},
-                    'tags': [],
+                    'tags': ['resource'],
                 },
             },
         },
@@ -112,7 +112,7 @@ def test_exception_annotated_on_method_with_custom_handler_with_dto(handler_retu
                         '200': {'description': ''},
                         '403': {**handler_spec, 'description': ''}
                     },
-                    'tags': [],
+                    'tags': ['resource'],
                 },
             },
         },

--- a/tests/winter_openapi/test_generator.py
+++ b/tests/winter_openapi/test_generator.py
@@ -1,7 +1,5 @@
 import pytest
 
-import winter
-from winter.web.routing import get_route
 from winter_openapi.generator import determine_path_prefix
 from winter_openapi.generator import get_url_path_tag
 from winter_openapi.generator import get_url_path_without_prefix

--- a/tests/winter_openapi/test_generator.py
+++ b/tests/winter_openapi/test_generator.py
@@ -55,62 +55,26 @@ def test_determine_path_prefix_when_prefix_exist(url_paths, expected_result):
     assert path_prefix == expected_result
 
 
-def test_get_url_path_tag():
-    class _TestAPI:
-        @winter.route_get('prefix/get-resource')
-        def get_resource(self):  # pragma: no cover
-            pass
-
-    route = get_route(_TestAPI.get_resource)
-
+@pytest.mark.parametrize(
+    'url_path, path_prefix, expected_result',
+    [
+        ('prefix/get-resource', '/prefix', 'get-resource'),
+        ('prefix/{id}/get-resource', '/prefix', None),
+        ('prefix', '/prefix', None),
+    ]
+)
+def test_get_url_path_tag(url_path, path_prefix, expected_result):
     # Act
-    url_path_tag = get_url_path_tag(route, '/prefix')
+    url_path_tag = get_url_path_tag(url_path, path_prefix)
 
     # Assert
-    assert url_path_tag == 'get-resource'
-
-
-def test_get_url_path_tag_ignore_params():
-    class _TestAPI:
-        @winter.route_get('prefix/{id}/get-resource')
-        def get_resource(self):  # pragma: no cover
-            pass
-
-    route = get_route(_TestAPI.get_resource)
-
-    # Act
-    url_path_tag = get_url_path_tag(route, '/prefix')
-
-    # Assert
-    assert url_path_tag is None
-
-
-def test_get_url_path_tag_when_url_path_is_prefix():
-    class _TestAPI:
-        @winter.route_get('prefix')
-        def get_resource(self):  # pragma: no cover
-            pass
-
-    route = get_route(_TestAPI.get_resource)
-
-    # Act
-    url_path_tag = get_url_path_tag(route, '/prefix')
-
-    # Assert
-    assert url_path_tag is None
+    assert url_path_tag == expected_result
 
 
 def test_get_url_path_tag_when_url_path_is_shorter_when_prefix():
-    class _TestAPI:
-        @winter.route_get('get-resource')
-        def get_resource(self):  # pragma: no cover
-            pass
-
-    route = get_route(_TestAPI.get_resource)
-
     # Act & Assert
     with pytest.raises(ValueError, match='Invalid path prefix /prefix-1/prefix-2 for url_path get-resource'):
-        get_url_path_tag(route, '/prefix-1/prefix-2')
+        get_url_path_tag('get-resource', '/prefix-1/prefix-2')
 
 
 @pytest.mark.parametrize(

--- a/tests/winter_openapi/test_generator.py
+++ b/tests/winter_openapi/test_generator.py
@@ -1,0 +1,148 @@
+import pytest
+
+import winter
+from winter.web.routing import get_route
+from winter_openapi.generator import determine_path_prefix
+from winter_openapi.generator import get_url_path_tag
+
+
+def test_determine_path_prefix_when_prefix_exist():
+    class _TestAPI:
+        @winter.route_get('prefix-1/prefix-2/get-resource')
+        def get_resource(self):  # pragma: no cover
+            pass
+
+        @winter.route_post('prefix-1/prefix-2/post-resource')
+        def post_resource(self):  # pragma: no cover
+            pass
+
+
+    route_1 = get_route(_TestAPI.get_resource)
+    route_2 = get_route(_TestAPI.post_resource)
+
+    # Act
+    path_prefix = determine_path_prefix([route_1, route_2])
+
+    # Assert
+    assert path_prefix == '/prefix-1/prefix-2'
+
+
+def test_determine_path_prefix_without_prefix():
+    class _TestAPI:
+        @winter.route_get('get-resource')
+        def get_resource(self):  # pragma: no cover
+            pass
+
+        @winter.route_post('post-resource')
+        def post_resource(self):  # pragma: no cover
+            pass
+
+
+    route_1 = get_route(_TestAPI.get_resource)
+    route_2 = get_route(_TestAPI.post_resource)
+
+    # Act
+    path_prefix = determine_path_prefix([route_1, route_2])
+
+    # Assert
+    assert path_prefix == '/'
+
+
+def test_determine_path_prefix_with_no_path():
+    class _TestAPI:
+        @winter.route_get()
+        def get_resource(self):  # pragma: no cover
+            pass
+
+        @winter.route_post()
+        def post_resource(self):  # pragma: no cover
+            pass
+
+
+    route_1 = get_route(_TestAPI.get_resource)
+    route_2 = get_route(_TestAPI.post_resource)
+
+    # Act
+    path_prefix = determine_path_prefix([route_1, route_2])
+
+    # Assert
+    assert path_prefix == '/'
+
+
+def test_determine_path_prefix_ignore_params():
+    class _TestAPI:
+        @winter.route_get('{id}/get-resource')
+        def get_resource(self):  # pragma: no cover
+            pass
+
+        @winter.route_post('{id}/post-resource')
+        def post_resource(self):  # pragma: no cover
+            pass
+
+
+    route_1 = get_route(_TestAPI.get_resource)
+    route_2 = get_route(_TestAPI.post_resource)
+
+    # Act
+    path_prefix = determine_path_prefix([route_1, route_2])
+
+    # Assert
+    assert path_prefix == '/'
+
+
+def test_get_url_path_tag():
+    class _TestAPI:
+        @winter.route_get('prefix/get-resource')
+        def get_resource(self):  # pragma: no cover
+            pass
+
+    route = get_route(_TestAPI.get_resource)
+
+    # Act
+    url_path_tag = get_url_path_tag(route, '/prefix')
+
+    # Assert
+    assert url_path_tag == 'get-resource'
+
+
+def test_get_url_path_tag_ignore_params():
+    class _TestAPI:
+        @winter.route_get('prefix/{id}/get-resource')
+        def get_resource(self):  # pragma: no cover
+            pass
+
+    route = get_route(_TestAPI.get_resource)
+
+    # Act
+    url_path_tag = get_url_path_tag(route, '/prefix')
+
+    # Assert
+    assert url_path_tag == ''
+
+
+def test_get_url_path_tag_when_url_path_is_prefix():
+    class _TestAPI:
+        @winter.route_get('prefix')
+        def get_resource(self):  # pragma: no cover
+            pass
+
+    route = get_route(_TestAPI.get_resource)
+
+    # Act
+    url_path_tag = get_url_path_tag(route, '/prefix')
+
+    # Assert
+    assert url_path_tag == ''
+
+
+def test_get_url_path_tag_when_url_path_is_shorter_when_prefix():
+    class _TestAPI:
+        @winter.route_get('get-resource')
+        def get_resource(self):  # pragma: no cover
+            pass
+
+    route = get_route(_TestAPI.get_resource)
+
+    # Act & Assert
+    with pytest.raises(ValueError, match='Invalid path prefix /prefix-1/prefix-2 for url_path get-resource'):
+        get_url_path_tag(route, '/prefix-1/prefix-2')

--- a/tests/winter_openapi/test_generator.py
+++ b/tests/winter_openapi/test_generator.py
@@ -97,7 +97,7 @@ def test_get_url_path_tag_when_url_path_is_prefix():
     url_path_tag = get_url_path_tag(route, '/prefix')
 
     # Assert
-    assert url_path_tag == is None
+    assert url_path_tag is None
 
 
 def test_get_url_path_tag_when_url_path_is_shorter_when_prefix():

--- a/tests/winter_openapi/test_generator.py
+++ b/tests/winter_openapi/test_generator.py
@@ -4,6 +4,7 @@ import winter
 from winter.web.routing import get_route
 from winter_openapi.generator import determine_path_prefix
 from winter_openapi.generator import get_url_path_tag
+from winter_openapi.generator import get_url_path_without_prefix
 
 
 def test_determine_path_prefix_when_prefix_exist():
@@ -12,7 +13,7 @@ def test_determine_path_prefix_when_prefix_exist():
         def get_resource(self):  # pragma: no cover
             pass
 
-        @winter.route_post('prefix-1/prefix-2/post-resource')
+        @winter.route_post('prefix-1/prefix-3/post-resource')
         def post_resource(self):  # pragma: no cover
             pass
 
@@ -24,7 +25,7 @@ def test_determine_path_prefix_when_prefix_exist():
     path_prefix = determine_path_prefix([route_1, route_2])
 
     # Assert
-    assert path_prefix == '/prefix-1/prefix-2'
+    assert path_prefix == '/prefix-1'
 
 
 def test_determine_path_prefix_without_prefix():
@@ -146,3 +147,21 @@ def test_get_url_path_tag_when_url_path_is_shorter_when_prefix():
     # Act & Assert
     with pytest.raises(ValueError, match='Invalid path prefix /prefix-1/prefix-2 for url_path get-resource'):
         get_url_path_tag(route, '/prefix-1/prefix-2')
+
+
+@pytest.mark.parametrize(
+    'url_path,path_prefix,expected_result',
+    [
+        ('/get-resource', '/', '/get-resource'),
+        ('/get-resource', '/prefix-1/prefix-2', '/get-resource'),
+        ('/prefix-1/prefix-2/get-resource', '/prefix-1/prefix-2', '/get-resource'),
+        ('/prefix-1/prefix-2/get-resource', '/prefix-1', '/prefix-2/get-resource'),
+        ('prefix-1/prefix-2/get-resource', '/prefix-1/prefix-2', '/get-resource'),
+    ]
+)
+def test_get_url_path_without_prefix(url_path, path_prefix, expected_result):
+    # Act
+    url_path_without_prefix = get_url_path_without_prefix(url_path, path_prefix)
+
+    # Assert
+    assert url_path_without_prefix == expected_result

--- a/tests/winter_openapi/test_generator.py
+++ b/tests/winter_openapi/test_generator.py
@@ -82,7 +82,7 @@ def test_get_url_path_tag_ignore_params():
     url_path_tag = get_url_path_tag(route, '/prefix')
 
     # Assert
-    assert url_path_tag == ''
+    assert url_path_tag is None
 
 
 def test_get_url_path_tag_when_url_path_is_prefix():
@@ -97,7 +97,7 @@ def test_get_url_path_tag_when_url_path_is_prefix():
     url_path_tag = get_url_path_tag(route, '/prefix')
 
     # Assert
-    assert url_path_tag == ''
+    assert url_path_tag == is None
 
 
 def test_get_url_path_tag_when_url_path_is_shorter_when_prefix():

--- a/tests/winter_openapi/test_generator.py
+++ b/tests/winter_openapi/test_generator.py
@@ -7,88 +7,52 @@ from winter_openapi.generator import get_url_path_tag
 from winter_openapi.generator import get_url_path_without_prefix
 
 
-def test_determine_path_prefix_when_prefix_exist():
-    class _TestAPI:
-        @winter.route_get('prefix-1/prefix-2/get-resource')
-        def get_resource(self):  # pragma: no cover
-            pass
-
-        @winter.route_post('prefix-1/prefix-3/post-resource')
-        def post_resource(self):  # pragma: no cover
-            pass
-
-
-    route_1 = get_route(_TestAPI.get_resource)
-    route_2 = get_route(_TestAPI.post_resource)
-
+@pytest.mark.parametrize(
+    ('url_paths', 'expected_result'),
+    [
+        (
+            [
+                'prefix-1/prefix-2/get-resource',
+                'prefix-1/prefix-3/post-resource'
+            ],
+            '/prefix-1',
+        ),
+        (
+            [
+                '/prefix-1/get-resource',
+                '/prefix-1/post-resource'
+            ],
+            '/prefix-1',
+        ),
+        (
+            [
+                'get-resource',
+                'post-resource'
+            ],
+            '/',
+        ),
+        (
+            [
+                '',
+                ''
+            ],
+            '/',
+        ),
+        (
+            [
+                '{id}/get-resource',
+                '{id}/post-resource'
+            ],
+            '/',
+        ),
+    ],
+)
+def test_determine_path_prefix_when_prefix_exist(url_paths, expected_result):
     # Act
-    path_prefix = determine_path_prefix([route_1, route_2])
+    path_prefix = determine_path_prefix(url_paths)
 
     # Assert
-    assert path_prefix == '/prefix-1'
-
-
-def test_determine_path_prefix_without_prefix():
-    class _TestAPI:
-        @winter.route_get('get-resource')
-        def get_resource(self):  # pragma: no cover
-            pass
-
-        @winter.route_post('post-resource')
-        def post_resource(self):  # pragma: no cover
-            pass
-
-
-    route_1 = get_route(_TestAPI.get_resource)
-    route_2 = get_route(_TestAPI.post_resource)
-
-    # Act
-    path_prefix = determine_path_prefix([route_1, route_2])
-
-    # Assert
-    assert path_prefix == '/'
-
-
-def test_determine_path_prefix_with_no_path():
-    class _TestAPI:
-        @winter.route_get()
-        def get_resource(self):  # pragma: no cover
-            pass
-
-        @winter.route_post()
-        def post_resource(self):  # pragma: no cover
-            pass
-
-
-    route_1 = get_route(_TestAPI.get_resource)
-    route_2 = get_route(_TestAPI.post_resource)
-
-    # Act
-    path_prefix = determine_path_prefix([route_1, route_2])
-
-    # Assert
-    assert path_prefix == '/'
-
-
-def test_determine_path_prefix_ignore_params():
-    class _TestAPI:
-        @winter.route_get('{id}/get-resource')
-        def get_resource(self):  # pragma: no cover
-            pass
-
-        @winter.route_post('{id}/post-resource')
-        def post_resource(self):  # pragma: no cover
-            pass
-
-
-    route_1 = get_route(_TestAPI.get_resource)
-    route_2 = get_route(_TestAPI.post_resource)
-
-    # Act
-    path_prefix = determine_path_prefix([route_1, route_2])
-
-    # Assert
-    assert path_prefix == '/'
+    assert path_prefix == expected_result
 
 
 def test_get_url_path_tag():

--- a/tests/winter_openapi/test_metadata_spec.py
+++ b/tests/winter_openapi/test_metadata_spec.py
@@ -33,7 +33,7 @@ def test_generate_openapi_with_all_args_spec():
                     'operationId': '_TestAPI.get_resource',
                     'parameters': [],
                     'responses': {'200': {'description': ''}},
-                    'tags': ['tag_value'],
+                    'tags': ['tag_value', 'resource'],
                 },
             },
         },

--- a/winter_openapi/generator.py
+++ b/winter_openapi/generator.py
@@ -51,9 +51,12 @@ def generate_openapi(
     tag_names = [tag_.name for tag_ in tags_]
     paths: Paths = {}
     operation_ids: Set[str] = set()
-    for key, group_routes in groupby(routes, key=lambda r: r.url_path):
-        path = _get_openapi_path(route=group_routes, operation_ids=operation_ids, tag_names=tag_names)
-        paths[key] = path
+    path_prefix = determine_path_prefix(routes)
+
+    for url_path, group_routes in groupby(routes, key=lambda r: r.url_path):
+        url_path_without_prefix = get_url_path_without_prefix(url_path, path_prefix)
+        path_item = _get_openapi_path(routes=group_routes, operation_ids=operation_ids, tag_names=tag_names, path_prefix=path_prefix)
+        paths[url_path_without_prefix] = path_item
 
     info = Info(title=title, version=version, description=description)
     servers_ = [Server(**server) for server in servers or []]
@@ -61,13 +64,17 @@ def generate_openapi(
     return open_api.dict(by_alias=True, exclude_none=True)
 
 
-def _get_openapi_path(*, route: Iterable[Route], operation_ids: Set[str], tag_names: Iterable[str]) -> PathItem:
+def _get_openapi_path(*, routes: Iterable[Route], operation_ids: Set[str], tag_names: Iterable[str], path_prefix: str) -> PathItem:
     path = {}
-    for route_item in route:
+    for route_item in routes:
         operation_id = route_item.method.full_name
         if operation_id in operation_ids:
             warnings.warn(f"Duplicate Operation ID {operation_id}")
         operation_ids.add(operation_id)
+        url_path_tag = get_url_path_tag(route_item, path_prefix)
+
+        if url_path_tag:
+            tag_names = list(tag_names) + [url_path_tag]
 
         operation = _get_openapi_operation(route=route_item, operation_id=operation_id, tag_names=tag_names)
         path[route_item.http_method.lower()] = operation
@@ -111,6 +118,36 @@ class CanNotInspectReturnType(Exception):
         component_cls = self._method.component.component_cls
         method_path = f'{component_cls.__module__}.{self._method.full_name}'
         return f'{method_path}: -> {self._return_type}: {self._message}'
+
+
+def get_url_path_without_prefix(url_path: str, path_prefix: Optional[str]) -> str:
+    # TODO: use removeprefix when python 3.9 will be used
+    path_prefix_stripped = path_prefix.strip('/')
+
+    if url_path.startswith(path_prefix_stripped):
+        url_path = url_path[len(path_prefix_stripped):]
+
+    return url_path
+
+
+def get_url_path_tag(route: Route, path_prefix: str) -> str:
+    path_prefix_segments = path_prefix.strip('/').split('/')
+    url_path_segments = route.url_path.strip('/').split('/')
+    path_prefix_segments = [segment for segment in path_prefix_segments if segment]  # remove empty segments like ['']
+
+    # for the cases with single route
+    if len(url_path_segments) <= len(path_prefix_segments):
+        if len(url_path_segments) == len(path_prefix_segments):
+            return ''
+        else:
+            raise ValueError(f'Invalid path prefix {path_prefix} for url_path {route.url_path}')
+
+    url_path_tag = url_path_segments[len(path_prefix_segments)]
+
+    if url_path_tag.startswith('{'):
+        return ''
+
+    return url_path_tag
 
 
 def get_route_parameters(route: Route) -> List[Parameter]:
@@ -158,6 +195,50 @@ def get_responses_schemas(route: Route) -> Responses:
         response_status = str(get_default_response_status(http_method, handle_method))
         responses[response_status] = _build_response_exception_handler_schema(handle_method)
     return responses
+
+
+def determine_path_prefix(routes: Sequence[Route]) -> str:
+    """
+    Given a list of all paths, return the common prefix which should be
+    discounted when generating a schema structure.
+
+    This will be the longest common string that does not include that last
+    component of the URL, or the last component before a path parameter.
+
+    For example:
+
+    /api/v1/users/
+    /api/v1/users/{pk}/
+
+    The path prefix is '/api/v1'
+    """
+    prefixes = []
+    for route in routes:
+        path = route.url_path
+        components = path.strip('/').split('/')
+        initial_components = []
+        for component in components:
+            if '{' in component:
+                break
+            initial_components.append(component)
+        prefix = '/'.join(initial_components[:-1])
+        if not prefix:
+            # We can just break early in the case that there's at least
+            # one URL that doesn't have a path prefix.
+            return '/'
+        prefixes.append('/' + prefix + '/')
+
+    split_paths = [path.strip('/').split('/') for path in prefixes]
+    s1 = min(split_paths)
+    s2 = max(split_paths)
+    common = s1
+
+    for i, c in enumerate(s1):
+        if c != s2[i]:
+            common = s1[:i]
+            break
+
+    return '/' + '/'.join(common)
 
 
 def _build_response_schema(method: ComponentMethod) -> Response:

--- a/winter_openapi/generator.py
+++ b/winter_openapi/generator.py
@@ -120,14 +120,15 @@ class CanNotInspectReturnType(Exception):
         return f'{method_path}: -> {self._return_type}: {self._message}'
 
 
-def get_url_path_without_prefix(url_path: str, path_prefix: Optional[str]) -> str:
+def get_url_path_without_prefix(url_path: str, path_prefix: str) -> str:
     # TODO: use removeprefix when python 3.9 will be used
     path_prefix_stripped = path_prefix.strip('/')
+    url_path_stripped = url_path.strip('/')
 
-    if url_path.startswith(path_prefix_stripped):
-        url_path = url_path[len(path_prefix_stripped):]
-
-    return url_path
+    if path_prefix_stripped and url_path_stripped.startswith(path_prefix_stripped):
+        return url_path_stripped[len(path_prefix_stripped):]
+    else:
+        return url_path
 
 
 def get_url_path_tag(route: Route, path_prefix: str) -> str:


### PR DESCRIPTION
1. Add url_path_tag to openapi operation tags. 
2. Use path without prefix with leading / as url path in specification