### PR TITLE
Schemas extracted to OpenAPI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [25.0.0] - 2024-07-26
+- Schemas extracted to OpenAPI components, are always referenced
+- Better nullable handling in OpenAPI schemas
+
 ## [24.0.1] - 2024-07-23
 - Added support of Python 3.12
 - Replaced openapi-schema-pydantic with openapi-pydantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "24.0.1"
+version = "25.0.0"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework with focus on python typing, dataclasses and modular design"
 authors = ["Alexander Egorov <mofr@zond.org>"]

--- a/tests/winter_openapi/test_api_request_and_response_spec.py
+++ b/tests/winter_openapi/test_api_request_and_response_spec.py
@@ -53,6 +53,12 @@ class Dataclass:
     nested: NestedDataclass
 
 
+@dataclass
+class DataclassWithOptionalField:
+    """DataclassWithOptionalField description"""
+    nested: Optional[NestedDataclass]
+
+
 class StringValueEnum(Enum):
     RED = 'red'
     GREEN = 'green'
@@ -151,9 +157,8 @@ class RequestBodyWithUndefined:
         {
             'schema': {
                 'items': {
-                    'nullable': False,
                     'description': 'Can be any value - string, number, boolean, array or object.',
-                    'nullable': False
+                    'nullable': False,
                 },
                 'type': 'array',
             },
@@ -164,9 +169,8 @@ class RequestBodyWithUndefined:
         {
             'schema': {
                 'items': {
-                    'nullable': False,
                     'description': 'Can be any value - string, number, boolean, array or object.',
-                    'nullable': False
+                    'nullable': False,
                 },
                 'type': 'array',
             },
@@ -189,6 +193,31 @@ class RequestBodyWithUndefined:
                 },
                 'required': ['nested'],
                 'title': 'Dataclass',
+                'type': 'object',
+            },
+        },
+    ),
+    (
+        DataclassWithOptionalField,
+        {
+            'schema': {
+                'description': 'DataclassWithOptionalField description',
+                'properties': {
+                    'nested': {
+                        'nullable': True,
+                        'allOf': [
+                            {
+                                'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                                'required': ['nested_number'],
+                                'title': 'NestedDataclass',
+                                'type': 'object',
+                                'description': 'NestedDataclass(nested_number: int)',
+                            },
+                        ],
+                    },
+                },
+                'required': ['nested'],
+                'title': 'DataclassWithOptionalField',
                 'type': 'object',
             },
         },

--- a/tests/winter_openapi/test_api_request_and_response_spec.py
+++ b/tests/winter_openapi/test_api_request_and_response_spec.py
@@ -24,7 +24,7 @@ from winter.core.utils import TypeWrapper
 from winter.data.pagination import Page
 from winter.web.routing import get_route
 from winter_openapi import generate_openapi
-from winter_openapi.generator import CanNotInspectReturnType
+from winter_openapi.generator import CanNotInspectType
 
 
 class IntegerValueEnum(Enum):
@@ -101,30 +101,107 @@ class RequestBodyWithUndefined:
     field_b: Union[str, Undefined] = Undefined()
 
 
-@pytest.mark.parametrize('type_hint, expected_response_info', [
-    (TestType, {'schema': {'format': 'int32', 'type': 'integer'}}),
-    (Id, {'schema': {'format': 'int32', 'type': 'integer'}}),
-    (uuid.UUID, {'schema': {'format': 'uuid', 'type': 'string'}}),
-    (bool, {'schema': {'type': 'boolean'}}),
-    (dict, {'schema': {'type': 'object'}}),
-    (float, {'schema': {'format': 'float', 'type': 'number'}}),
-    (decimal.Decimal, {'schema': {'format': 'decimal', 'type': 'string'}}),
-    (Optional[int], {'schema': {'format': 'int32', 'type': 'integer', 'nullable': True}}),
-    (datetime.datetime, {'schema': {'format': 'date-time', 'type': 'string'}}),
-    (datetime.date, {'schema': {'format': 'date', 'type': 'string'}}),
-    (int, {'schema': {'format': 'int32', 'type': 'integer'}}),
-    (str, {'schema': {'type': 'string'}}),
-    (bytes, {'schema': {'format': 'bytes', 'type': 'string'}}),
-    (IntegerEnum, {'schema': {'enum': [1, 2], 'format': 'int32', 'type': 'integer'}}),
-    (IntegerValueEnum, {'schema': {'enum': [1, 2], 'format': 'int32', 'type': 'integer'}}),
-    (StringValueEnum, {'schema': {'enum': ['red', 'green'], 'type': 'string'}}),
-    (StringEnum, {'schema': {'enum': ['RED', 'GREEN'], 'type': 'string'}}),
-    (MixedValueEnum, {'schema': {'enum': [123, 'green'], 'type': 'string'}}),
+@pytest.mark.parametrize('type_hint, expected_response_info, expected_components', [
+    (
+        TestType,
+        {'schema': {'format': 'int32', 'type': 'integer'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        Id,
+        {'schema': {'format': 'int32', 'type': 'integer'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        uuid.UUID,
+        {'schema': {'format': 'uuid', 'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        bool,
+        {'schema': {'type': 'boolean'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        dict,
+        {'schema': {'type': 'object'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        float,
+        {'schema': {'format': 'float', 'type': 'number'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        decimal.Decimal,
+        {'schema': {'format': 'decimal', 'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        Optional[int],
+        {'schema': {'format': 'int32', 'type': 'integer', 'nullable': True}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        datetime.datetime,
+        {'schema': {'format': 'date-time', 'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        datetime.date,
+        {'schema': {'format': 'date', 'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        int,
+        {'schema': {'format': 'int32', 'type': 'integer'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        str,
+        {'schema': {'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        bytes,
+        {'schema': {'format': 'bytes', 'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        IntegerEnum,
+        {'schema': {'enum': [1, 2], 'format': 'int32', 'type': 'integer'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        IntegerValueEnum,
+        {'schema': {'enum': [1, 2], 'format': 'int32', 'type': 'integer'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        StringValueEnum,
+        {'schema': {'enum': ['red', 'green'], 'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        StringEnum,
+        {'schema': {'enum': ['RED', 'GREEN'], 'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
+    (
+        MixedValueEnum,
+        {'schema': {'enum': [123, 'green'], 'type': 'string'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
     (
         List[IntegerValueEnum],
-        {'schema': {'items': {'enum': [1, 2], 'format': 'int32', 'type': 'integer'}, 'type': 'array'}}
+        {'schema': {'items': {'enum': [1, 2], 'format': 'int32', 'type': 'integer'}, 'type': 'array'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
     ),
-    (List[StringValueEnum], {'schema': {'items': {'enum': ['red', 'green'], 'type': 'string'}, 'type': 'array'}}),
+    (
+        List[StringValueEnum],
+        {'schema': {'items': {'enum': ['red', 'green'], 'type': 'string'}, 'type': 'array'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
     (
         Any,
         {
@@ -132,7 +209,8 @@ class RequestBodyWithUndefined:
                 'description': 'Can be any value - string, number, boolean, array or object.',
                 'nullable': False
             }
-        }
+        },
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
     ),
     (
         TypeVarItem,
@@ -141,7 +219,8 @@ class RequestBodyWithUndefined:
                 'description': 'Can be any value - string, number, boolean, array or object.',
                 'nullable': False
             }
-        }
+        },
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
     ),
     (
         Optional[Any],
@@ -150,7 +229,8 @@ class RequestBodyWithUndefined:
                 'description': 'Can be any value - string, number, boolean, array or object.',
                 'nullable': True
             }
-        }
+        },
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
     ),
     (
         List,
@@ -163,6 +243,7 @@ class RequestBodyWithUndefined:
                 'type': 'array',
             },
         },
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
     ),
     (
         List[Any],
@@ -175,25 +256,39 @@ class RequestBodyWithUndefined:
                 'type': 'array',
             },
         },
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
     ),
-    (Set[int], {'schema': {'items': {'format': 'int32', 'type': 'integer'}, 'type': 'array'}}),
+    (
+        Set[int],
+        {'schema': {'items': {'format': 'int32', 'type': 'integer'}, 'type': 'array'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
     (
         Dataclass,
         {
             'schema': {
-                'description': 'Parent data class description',
-                'properties': {
-                    'nested': {
-                        'description': 'doc string for nested field',
-                        'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                        'required': ['nested_number'],
-                        'title': 'NestedDataclass',
-                        'type': 'object',
+                '$ref': '#/components/schemas/Dataclass',
+            },
+        },
+        {
+            'parameters': {},
+            'responses': {},
+            'schemas': {
+                'Dataclass': {
+                    'description': 'Parent data class description',
+                    'properties': {
+                        'nested': {
+                            'description': 'doc string for nested field',
+                            'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                            'required': ['nested_number'],
+                            'title': 'NestedDataclass',
+                            'type': 'object',
+                        },
                     },
-                },
-                'required': ['nested'],
-                'title': 'Dataclass',
-                'type': 'object',
+                    'required': ['nested'],
+                    'title': 'Dataclass',
+                    'type': 'object',
+                }
             },
         },
     ),
@@ -201,24 +296,33 @@ class RequestBodyWithUndefined:
         DataclassWithOptionalField,
         {
             'schema': {
-                'description': 'DataclassWithOptionalField description',
-                'properties': {
-                    'nested': {
-                        'nullable': True,
-                        'allOf': [
-                            {
-                                'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                                'required': ['nested_number'],
-                                'title': 'NestedDataclass',
-                                'type': 'object',
-                                'description': 'NestedDataclass(nested_number: int)',
-                            },
-                        ],
+                '$ref': '#/components/schemas/DataclassWithOptionalField',
+            },
+        },
+        {
+            'parameters': {},
+            'responses': {},
+            'schemas': {
+                'DataclassWithOptionalField': {
+                    'description': 'DataclassWithOptionalField description',
+                    'properties': {
+                        'nested': {
+                            'nullable': True,
+                            'allOf': [
+                                {
+                                    'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                                    'required': ['nested_number'],
+                                    'title': 'NestedDataclass',
+                                    'type': 'object',
+                                    'description': 'NestedDataclass(nested_number: int)',
+                                },
+                            ],
+                        },
                     },
-                },
-                'required': ['nested'],
-                'title': 'DataclassWithOptionalField',
-                'type': 'object',
+                    'required': ['nested'],
+                    'title': 'DataclassWithOptionalField',
+                    'type': 'object',
+                }
             },
         },
     ),
@@ -226,75 +330,102 @@ class RequestBodyWithUndefined:
         Page[NestedDataclass],
         {
             'schema': {
-                'properties': {
-                    'meta': {
-                        'properties': {
-                            'limit': {'nullable': True, 'type': 'integer'},
-                            'next': {'format': 'uri', 'nullable': True, 'type': 'string'},
-                            'offset': {'nullable': True, 'type': 'integer'},
-                            'previous': {'format': 'uri', 'nullable': True, 'type': 'string'},
-                            'total_count': {'type': 'integer'},
-                        },
-                        'required': ['total_count', 'limit', 'offset', 'previous', 'next'],
-                        'title': 'PageMetaOfNestedDataclass',
-                        'type': 'object',
-                    },
-                    'objects': {
-                        'items': {
-                            'description': 'NestedDataclass(nested_number: int)',
-                            'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                            'required': ['nested_number'],
-                            'title': 'NestedDataclass',
+                '$ref': '#/components/schemas/PageOfNestedDataclass',
+            },
+        },
+        {
+            'parameters': {},
+            'responses': {},
+            'schemas': {
+                'PageOfNestedDataclass': {
+                    'properties': {
+                        'meta': {
+                            'properties': {
+                                'limit': {'nullable': True, 'type': 'integer'},
+                                'next': {'format': 'uri', 'nullable': True, 'type': 'string'},
+                                'offset': {'nullable': True, 'type': 'integer'},
+                                'previous': {'format': 'uri', 'nullable': True, 'type': 'string'},
+                                'total_count': {'type': 'integer'},
+                            },
+                            'required': ['total_count', 'limit', 'offset', 'previous', 'next'],
+                            'title': 'PageMetaOfNestedDataclass',
                             'type': 'object',
                         },
-                        'type': 'array',
+                        'objects': {
+                            'items': {
+                                'description': 'NestedDataclass(nested_number: int)',
+                                'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                                'required': ['nested_number'],
+                                'title': 'NestedDataclass',
+                                'type': 'object',
+                            },
+                            'type': 'array',
+                        },
                     },
-                },
-                'required': ['meta', 'objects'],
-                'title': 'PageOfNestedDataclass',
-                'type': 'object',
+                    'required': ['meta', 'objects'],
+                    'title': 'PageOfNestedDataclass',
+                    'type': 'object',
+                }
             },
-        }
+        },
     ),
     (
         CustomPage[int],
         {
             'schema': {
-                'properties': {
-                    'meta': {
-                        'properties': {
-                            'extra': {'type': 'string'},
-                            'limit': {'nullable': True, 'type': 'integer'},
-                            'next': {'format': 'uri', 'nullable': True, 'type': 'string'},
-                            'offset': {'nullable': True, 'type': 'integer'},
-                            'previous': {'format': 'uri', 'nullable': True, 'type': 'string'},
-                            'total_count': {'type': 'integer'}},
-                        'required': ['total_count', 'limit', 'offset', 'previous', 'next', 'extra'],
-                        'title': 'PageMetaOfInteger',
-                        'type': 'object',
-                    },
-                    'objects': {'items': {'format': 'int32', 'type': 'integer'}, 'type': 'array'},
-                },
-                'required': ['meta', 'objects'],
-                'title': 'PageOfInteger',
-                'type': 'object',
+                '$ref': '#/components/schemas/PageOfInteger',
             },
-        }
+        },
+        {
+            'parameters': {},
+            'responses': {},
+            'schemas': {
+                'PageOfInteger': {
+                    'properties': {
+                        'meta': {
+                            'properties': {
+                                'extra': {'type': 'string'},
+                                'limit': {'nullable': True, 'type': 'integer'},
+                                'next': {'format': 'uri', 'nullable': True, 'type': 'string'},
+                                'offset': {'nullable': True, 'type': 'integer'},
+                                'previous': {'format': 'uri', 'nullable': True, 'type': 'string'},
+                                'total_count': {'type': 'integer'}},
+                            'required': ['total_count', 'limit', 'offset', 'previous', 'next', 'extra'],
+                            'title': 'PageMetaOfInteger',
+                            'type': 'object',
+                        },
+                        'objects': {'items': {'format': 'int32', 'type': 'integer'}, 'type': 'array'},
+                    },
+                    'required': ['meta', 'objects'],
+                    'title': 'PageOfInteger',
+                    'type': 'object',
+                }
+            },
+        },
     ),
     (
         DataclassWrapper[NestedDataclass],
         {
             'schema': {
-                'description': 'NestedDataclass(nested_number: int)',
-                'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                'required': ['nested_number'],
-                'title': 'NestedDataclass',
-                'type': 'object',
+                '$ref': '#/components/schemas/NestedDataclass',
+            },
+        },
+        {
+            'parameters': {},
+            'responses': {},
+            'schemas': {
+                'NestedDataclass': {
+                    'description': 'NestedDataclass(nested_number: int)',
+                    'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                    'required': ['nested_number'],
+                    'title': 'NestedDataclass',
+                    'type': 'object',
+                }
             },
         },
     ),
 ])
-def test_response_return_type(type_hint, expected_response_info):
+def test_response_return_type(type_hint, expected_response_info, expected_components):
     class _TestAPI:
         @winter.route_get('/types/')
         def simple_method(self) -> type_hint:  # pragma: no cover
@@ -314,7 +445,6 @@ def test_response_return_type(type_hint, expected_response_info):
             },
         },
         'tags': ['types'],
-
     }
     # Act
     result = generate_openapi(title='title', version='1.0.0', routes=[route])
@@ -322,6 +452,7 @@ def test_response_return_type(type_hint, expected_response_info):
     # Assert
     method_info = result['paths']['/types/']['get']
     assert method_info == expected_method_info, type_hint
+    assert result['components'] == expected_components
 
 
 def test_response_with_invalid_return_type():
@@ -332,39 +463,53 @@ def test_response_with_invalid_return_type():
 
     route = get_route(_TestAPI.with_invalid_return_type)
 
-    with pytest.raises(CanNotInspectReturnType) as e:
+    with pytest.raises(CanNotInspectType) as e:
         # Act
         generate_openapi(title='title', version='1.0.0', routes=[route])
 
     assert repr(e.value) == (
-        'CanNotInspectReturnType(test_api_request_and_response_spec._TestAPI.with_invalid_return_type: '
+        'CanNotInspectType(test_api_request_and_response_spec._TestAPI.with_invalid_return_type: '
         "-> <class 'object'>: Unknown type: <class 'object'>)"
     )
 
 
-@pytest.mark.parametrize('type_hint, expected_request_body_spec', [
+@pytest.mark.parametrize('type_hint, expected_request_body_spec, expected_components', [
     (
         List[IntegerValueEnum],
-        {'schema': {'items': {'enum': [1, 2], 'format': 'int32', 'type': 'integer'}, 'type': 'array'}}
+        {'schema': {'items': {'enum': [1, 2], 'format': 'int32', 'type': 'integer'}, 'type': 'array'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
     ),
-    (List[StringValueEnum], {'schema': {'items': {'enum': ['red', 'green'], 'type': 'string'}, 'type': 'array'}}),
+    (
+        List[StringValueEnum],
+        {'schema': {'items': {'enum': ['red', 'green'], 'type': 'string'}, 'type': 'array'}},
+        {'parameters': {}, 'responses': {}, 'schemas': {}},
+    ),
     (
         Dataclass,
         {
             'schema': {
-                'description': 'Parent data class description',
-                'properties': {
-                    'nested': {
-                        'description': 'doc string for nested field',
-                        'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                        'required': ['nested_number'],
-                        'title': 'NestedDataclassInput',
-                        'type': 'object',
+                '$ref': '#/components/schemas/DataclassInput',
+            },
+        },
+        {
+            'parameters': {},
+            'responses': {},
+            'schemas': {
+                'DataclassInput': {
+                    'description': 'Parent data class description',
+                    'properties': {
+                        'nested': {
+                            'description': 'doc string for nested field',
+                            'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                            'required': ['nested_number'],
+                            'title': 'NestedDataclassInput',
+                            'type': 'object',
+                        },
                     },
+                    'required': ['nested'],
+                    'title': 'DataclassInput',
+                    'type': 'object',
                 },
-                'required': ['nested'],
-                'title': 'DataclassInput',
-                'type': 'object',
             },
         },
     ),
@@ -372,18 +517,27 @@ def test_response_with_invalid_return_type():
         RequestBodyWithUndefined,
         {
             'schema': {
-                'title': 'RequestBodyWithUndefinedInput',
-                'description': 'Some description',
-                'type': 'object',
-                'properties': {
-                    'field_a': {'type': 'string'},
-                    'field_b': {'type': 'string'},
+                '$ref': '#/components/schemas/RequestBodyWithUndefinedInput',
+            },
+        },
+        {
+            'parameters': {},
+            'responses': {},
+            'schemas': {
+                'RequestBodyWithUndefinedInput': {
+                    'title': 'RequestBodyWithUndefinedInput',
+                    'description': 'Some description',
+                    'type': 'object',
+                    'properties': {
+                        'field_a': {'type': 'string'},
+                        'field_b': {'type': 'string'},
+                    },
                 },
             },
         },
     ),
 ])
-def test_request_type(type_hint, expected_request_body_spec):
+def test_request_type(type_hint, expected_request_body_spec, expected_components):
     class _TestAPI:
         @winter.route_post('/types/')
         @winter.request_body('data')
@@ -398,3 +552,4 @@ def test_request_type(type_hint, expected_request_body_spec):
     # Assert
     method_info = result['paths']['/types/']['post']['requestBody']
     assert method_info == {'content': {'application/json': expected_request_body_spec}, 'required': False}
+    assert result['components'] == expected_components

--- a/tests/winter_openapi/test_api_request_and_response_spec.py
+++ b/tests/winter_openapi/test_api_request_and_response_spec.py
@@ -37,6 +37,7 @@ TestType = NewType('TestType', int)
 
 @dataclass
 class NestedDataclass:
+    """NestedDataclass"""
     nested_number: int
 
 
@@ -275,7 +276,7 @@ class RequestBodyWithUndefined:
             'responses': {},
             'schemas': {
                 'NestedDataclass': {
-                    'description': 'NestedDataclass(nested_number: int)',
+                    'description': 'NestedDataclass',
                     'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
                     'required': ['nested_number'],
                     'title': 'NestedDataclass',
@@ -311,7 +312,7 @@ class RequestBodyWithUndefined:
                     'required': ['nested_number'],
                     'title': 'NestedDataclass',
                     'type': 'object',
-                    'description': 'NestedDataclass(nested_number: int)',
+                    'description': 'NestedDataclass',
                 },
                 'DataclassWithOptionalField': {
                     'description': 'DataclassWithOptionalField description',
@@ -344,10 +345,6 @@ class RequestBodyWithUndefined:
             'responses': {},
             'schemas': {
                 'PageMetaOfNestedDataclass': {
-                    'description': (
-                        'PageMetaOfNestedDataclass(total_count: int, limit: Union[int, NoneType], '
-                        'offset: Union[int, NoneType], previous: Union[str, NoneType], next: Union[str, NoneType])'
-                    ),
                     'properties': {
                         'limit': {'format': 'int32', 'nullable': True, 'type': 'integer'},
                         'offset': {'format': 'int32', 'nullable': True, 'type': 'integer'},
@@ -360,18 +357,13 @@ class RequestBodyWithUndefined:
                     'type': 'object',
                 },
                 'NestedDataclass': {
-                    'description': 'NestedDataclass(nested_number: int)',
+                    'description': 'NestedDataclass',
                     'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
                     'required': ['nested_number'],
                     'title': 'NestedDataclass',
                     'type': 'object',
                 },
                 'PageOfNestedDataclass': {
-                    'description': (
-                        'PageOfNestedDataclass('
-                        'meta: winter_openapi.inspectors.page_inspector.PageMetaOfNestedDataclass, '
-                        'objects: List[test_api_request_and_response_spec.NestedDataclass])'
-                    ),
                     'properties': {
                         'meta': {
                             '$ref': '#/components/schemas/PageMetaOfNestedDataclass',
@@ -402,11 +394,6 @@ class RequestBodyWithUndefined:
             'responses': {},
             'schemas': {
                 'PageMetaOfInteger': {
-                    'description': (
-                        'PageMetaOfInteger(total_count: int, limit: Union[int, NoneType], '
-                        'offset: Union[int, NoneType], previous: Union[str, NoneType], next: Union[str, NoneType], '
-                        'extra: str)'
-                    ),
                     'properties': {
                         'extra': {'type': 'string'},
                         'limit': {'format': 'int32', 'nullable': True, 'type': 'integer'},
@@ -419,10 +406,6 @@ class RequestBodyWithUndefined:
                     'type': 'object',
                 },
                 'PageOfInteger': {
-                    'description': (
-                        'PageOfInteger(meta: winter_openapi.inspectors.page_inspector.PageMetaOfInteger, '
-                        'objects: List[int])'
-                    ),
                     'properties': {
                         'meta': {
                             '$ref': '#/components/schemas/PageMetaOfInteger',
@@ -448,7 +431,7 @@ class RequestBodyWithUndefined:
             'responses': {},
             'schemas': {
                 'NestedDataclass': {
-                    'description': 'NestedDataclass(nested_number: int)',
+                    'description': 'NestedDataclass',
                     'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
                     'required': ['nested_number'],
                     'title': 'NestedDataclass',
@@ -529,7 +512,7 @@ def test_response_with_invalid_return_type():
             'responses': {},
             'schemas': {
                 'NestedDataclassInput': {
-                    'description': 'NestedDataclass(nested_number: int)',
+                    'description': 'NestedDataclass',
                     'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
                     'required': ['nested_number'],
                     'title': 'NestedDataclassInput',
@@ -627,7 +610,7 @@ def test_reuse_schema():
             'responses': {},
             'schemas': {
                 'NestedDataclass': {
-                    'description': 'NestedDataclass(nested_number: int)',
+                    'description': 'NestedDataclass',
                     'properties': {
                         'nested_number': {
                             'format': 'int32',
@@ -639,7 +622,7 @@ def test_reuse_schema():
                     'type': 'object',
                 },
                 'NestedDataclassInput': {
-                    'description': 'NestedDataclass(nested_number: int)',
+                    'description': 'NestedDataclass',
                     'properties': {
                         'nested_number': {
                             'format': 'int32',

--- a/tests/winter_openapi/test_api_request_and_response_spec.py
+++ b/tests/winter_openapi/test_api_request_and_response_spec.py
@@ -274,15 +274,18 @@ class RequestBodyWithUndefined:
             'parameters': {},
             'responses': {},
             'schemas': {
+                'NestedDataclass': {
+                    'description': 'NestedDataclass(nested_number: int)',
+                    'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                    'required': ['nested_number'],
+                    'title': 'NestedDataclass',
+                    'type': 'object',
+                },
                 'Dataclass': {
                     'description': 'Parent data class description',
                     'properties': {
                         'nested': {
-                            'description': 'doc string for nested field',
-                            'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                            'required': ['nested_number'],
-                            'title': 'NestedDataclass',
-                            'type': 'object',
+                            '$ref': '#/components/schemas/NestedDataclass',
                         },
                     },
                     'required': ['nested'],
@@ -303,6 +306,13 @@ class RequestBodyWithUndefined:
             'parameters': {},
             'responses': {},
             'schemas': {
+                'NestedDataclass': {
+                    'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                    'required': ['nested_number'],
+                    'title': 'NestedDataclass',
+                    'type': 'object',
+                    'description': 'NestedDataclass(nested_number: int)',
+                },
                 'DataclassWithOptionalField': {
                     'description': 'DataclassWithOptionalField description',
                     'properties': {
@@ -310,11 +320,7 @@ class RequestBodyWithUndefined:
                             'nullable': True,
                             'allOf': [
                                 {
-                                    'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                                    'required': ['nested_number'],
-                                    'title': 'NestedDataclass',
-                                    'type': 'object',
-                                    'description': 'NestedDataclass(nested_number: int)',
+                                    '$ref': '#/components/schemas/NestedDataclass',
                                 },
                             ],
                         },
@@ -337,27 +343,42 @@ class RequestBodyWithUndefined:
             'parameters': {},
             'responses': {},
             'schemas': {
+                'PageMetaOfNestedDataclass': {
+                    'description': (
+                        'PageMetaOfNestedDataclass(total_count: int, limit: Union[int, NoneType], '
+                        'offset: Union[int, NoneType], previous: Union[str, NoneType], next: Union[str, NoneType])'
+                    ),
+                    'properties': {
+                        'limit': {'format': 'int32', 'nullable': True, 'type': 'integer'},
+                        'offset': {'format': 'int32', 'nullable': True, 'type': 'integer'},
+                        'next': {'nullable': True, 'type': 'string'},
+                        'previous': {'nullable': True, 'type': 'string'},
+                        'total_count': {'format': 'int32', 'type': 'integer'},
+                    },
+                    'required': ['total_count', 'limit', 'offset', 'previous', 'next'],
+                    'title': 'PageMetaOfNestedDataclass',
+                    'type': 'object',
+                },
+                'NestedDataclass': {
+                    'description': 'NestedDataclass(nested_number: int)',
+                    'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                    'required': ['nested_number'],
+                    'title': 'NestedDataclass',
+                    'type': 'object',
+                },
                 'PageOfNestedDataclass': {
+                    'description': (
+                        'PageOfNestedDataclass('
+                        'meta: winter_openapi.inspectors.page_inspector.PageMetaOfNestedDataclass, '
+                        'objects: List[test_api_request_and_response_spec.NestedDataclass])'
+                    ),
                     'properties': {
                         'meta': {
-                            'properties': {
-                                'limit': {'nullable': True, 'type': 'integer'},
-                                'next': {'format': 'uri', 'nullable': True, 'type': 'string'},
-                                'offset': {'nullable': True, 'type': 'integer'},
-                                'previous': {'format': 'uri', 'nullable': True, 'type': 'string'},
-                                'total_count': {'type': 'integer'},
-                            },
-                            'required': ['total_count', 'limit', 'offset', 'previous', 'next'],
-                            'title': 'PageMetaOfNestedDataclass',
-                            'type': 'object',
+                            '$ref': '#/components/schemas/PageMetaOfNestedDataclass',
                         },
                         'objects': {
                             'items': {
-                                'description': 'NestedDataclass(nested_number: int)',
-                                'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                                'required': ['nested_number'],
-                                'title': 'NestedDataclass',
-                                'type': 'object',
+                                '$ref': '#/components/schemas/NestedDataclass',
                             },
                             'type': 'array',
                         },
@@ -380,19 +401,31 @@ class RequestBodyWithUndefined:
             'parameters': {},
             'responses': {},
             'schemas': {
+                'PageMetaOfInteger': {
+                    'description': (
+                        'PageMetaOfInteger(total_count: int, limit: Union[int, NoneType], '
+                        'offset: Union[int, NoneType], previous: Union[str, NoneType], next: Union[str, NoneType], '
+                        'extra: str)'
+                    ),
+                    'properties': {
+                        'extra': {'type': 'string'},
+                        'limit': {'format': 'int32', 'nullable': True, 'type': 'integer'},
+                        'offset': {'format': 'int32', 'nullable': True, 'type': 'integer'},
+                        'next': {'nullable': True, 'type': 'string'},
+                        'previous': {'nullable': True, 'type': 'string'},
+                        'total_count': {'format': 'int32', 'type': 'integer'}},
+                    'required': ['total_count', 'limit', 'offset', 'previous', 'next', 'extra'],
+                    'title': 'PageMetaOfInteger',
+                    'type': 'object',
+                },
                 'PageOfInteger': {
+                    'description': (
+                        'PageOfInteger(meta: winter_openapi.inspectors.page_inspector.PageMetaOfInteger, '
+                        'objects: List[int])'
+                    ),
                     'properties': {
                         'meta': {
-                            'properties': {
-                                'extra': {'type': 'string'},
-                                'limit': {'nullable': True, 'type': 'integer'},
-                                'next': {'format': 'uri', 'nullable': True, 'type': 'string'},
-                                'offset': {'nullable': True, 'type': 'integer'},
-                                'previous': {'format': 'uri', 'nullable': True, 'type': 'string'},
-                                'total_count': {'type': 'integer'}},
-                            'required': ['total_count', 'limit', 'offset', 'previous', 'next', 'extra'],
-                            'title': 'PageMetaOfInteger',
-                            'type': 'object',
+                            '$ref': '#/components/schemas/PageMetaOfInteger',
                         },
                         'objects': {'items': {'format': 'int32', 'type': 'integer'}, 'type': 'array'},
                     },
@@ -468,8 +501,8 @@ def test_response_with_invalid_return_type():
         generate_openapi(title='title', version='1.0.0', routes=[route])
 
     assert repr(e.value) == (
-        'CanNotInspectType(test_api_request_and_response_spec._TestAPI.with_invalid_return_type: '
-        "-> <class 'object'>: Unknown type: <class 'object'>)"
+        "CanNotInspectType(test_api_request_and_response_spec._TestAPI.with_invalid_return_type: "
+        "Unknown type: <class 'object'>)"
     )
 
 
@@ -495,15 +528,18 @@ def test_response_with_invalid_return_type():
             'parameters': {},
             'responses': {},
             'schemas': {
+                'NestedDataclassInput': {
+                    'description': 'NestedDataclass(nested_number: int)',
+                    'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
+                    'required': ['nested_number'],
+                    'title': 'NestedDataclassInput',
+                    'type': 'object',
+                },
                 'DataclassInput': {
                     'description': 'Parent data class description',
                     'properties': {
                         'nested': {
-                            'description': 'doc string for nested field',
-                            'properties': {'nested_number': {'format': 'int32', 'type': 'integer'}},
-                            'required': ['nested_number'],
-                            'title': 'NestedDataclassInput',
-                            'type': 'object',
+                            '$ref': '#/components/schemas/NestedDataclassInput',
                         },
                     },
                     'required': ['nested'],
@@ -553,3 +589,201 @@ def test_request_type(type_hint, expected_request_body_spec, expected_components
     method_info = result['paths']['/types/']['post']['requestBody']
     assert method_info == {'content': {'application/json': expected_request_body_spec}, 'required': False}
     assert result['components'] == expected_components
+
+
+def test_reuse_schema():
+    class _TestAPI:  # pragma: no cover
+        @winter.route_get('/method_1/')
+        def method_1(self) -> Dataclass:
+            pass
+
+        @winter.route_get('/method_2/')
+        def method_2(self) -> Dataclass:
+            pass
+
+        @winter.route_post('/method_3/')
+        @winter.request_body('data')
+        def method_3(self, data: Dataclass):
+            pass
+
+        @winter.route_post('/method_4/')
+        @winter.request_body('data')
+        def method_4(self, data: Dataclass):
+            pass
+
+    result = generate_openapi(
+        title='title',
+        version='1.0.0',
+        routes=[
+            get_route(_TestAPI.method_1),
+            get_route(_TestAPI.method_2),
+            get_route(_TestAPI.method_3),
+            get_route(_TestAPI.method_4),
+        ],
+    )
+    assert result == {
+        'components': {
+            'parameters': {},
+            'responses': {},
+            'schemas': {
+                'NestedDataclass': {
+                    'description': 'NestedDataclass(nested_number: int)',
+                    'properties': {
+                        'nested_number': {
+                            'format': 'int32',
+                            'type': 'integer',
+                        },
+                    },
+                    'required': ['nested_number'],
+                    'title': 'NestedDataclass',
+                    'type': 'object',
+                },
+                'NestedDataclassInput': {
+                    'description': 'NestedDataclass(nested_number: int)',
+                    'properties': {
+                        'nested_number': {
+                            'format': 'int32',
+                            'type': 'integer',
+                        },
+                    },
+                    'required': ['nested_number'],
+                    'title': 'NestedDataclassInput',
+                    'type': 'object',
+                },
+                'Dataclass': {
+                    'description': 'Parent data class description',
+                    'properties': {
+                        'nested': {
+                            '$ref': '#/components/schemas/NestedDataclass',
+                        },
+                    },
+                    'required': ['nested'],
+                    'title': 'Dataclass',
+                    'type': 'object',
+                },
+                'DataclassInput': {
+                    'description': 'Parent data class description',
+                    'properties': {
+                        'nested': {
+                            '$ref': '#/components/schemas/NestedDataclassInput',
+                        },
+                    },
+                    'required': ['nested'],
+                    'title': 'DataclassInput',
+                    'type': 'object',
+                },
+            },
+        },
+        'info': {'title': 'title', 'version': '1.0.0'},
+        'openapi': '3.0.3',
+        'paths': {
+            '/method_1/': {
+                'get': {
+                    'deprecated': False,
+                    'operationId': '_TestAPI.method_1',
+                    'parameters': [],
+                    'responses': {
+                        '200': {
+                            'content': {
+                                'application/json': {
+                                    'schema': {'$ref': '#/components/schemas/Dataclass'},
+                                },
+                            },
+                            'description': '',
+                        },
+                    },
+                    'tags': ['method_1'],
+                },
+            },
+            '/method_2/': {
+                'get': {
+                    'deprecated': False,
+                    'operationId': '_TestAPI.method_2',
+                    'parameters': [],
+                    'responses': {
+                        '200': {
+                            'content': {
+                                'application/json': {
+                                    'schema': {'$ref': '#/components/schemas/Dataclass'},
+                                },
+                            },
+                            'description': '',
+                        },
+                    },
+                    'tags': ['method_2'],
+                },
+            },
+            '/method_3/': {
+                'post': {
+                    'deprecated': False,
+                    'operationId': '_TestAPI.method_3',
+                    'parameters': [],
+                    'requestBody': {
+                        'content': {
+                            'application/json': {
+                                'schema': {'$ref': '#/components/schemas/DataclassInput'},
+                            },
+                        },
+                        'required': False,
+                    },
+                    'responses': {
+                        '200': {'description': ''},
+                    },
+                    'tags': ['method_3'],
+                },
+            },
+            '/method_4/': {
+                'post': {
+                    'deprecated': False,
+                    'operationId': '_TestAPI.method_4',
+                    'parameters': [],
+                    'requestBody': {
+                        'content': {
+                            'application/json': {
+                                'schema': {'$ref': '#/components/schemas/DataclassInput'},
+                            },
+                        },
+                        'required': False
+                    },
+                    'responses': {
+                        '200': {'description': ''},
+                    },
+                    'tags': ['method_4'],
+                },
+            },
+        },
+        'servers': [{'url': '/'}],
+        'tags': [],
+    }
+
+
+def test_raises_for_type_duplicates():
+    class DuplicateTypes:
+        @dataclass
+        class Dataclass:
+            nested: NestedDataclass
+
+    class _TestAPI:  # pragma: no cover
+        @winter.route_get('/method_1/')
+        def method_1(self) -> Dataclass:
+            pass
+
+        @winter.route_get('/method_2/')
+        def method_2(self) -> DuplicateTypes.Dataclass:
+            pass
+
+    with pytest.raises(ValueError) as e:
+        generate_openapi(
+            title='title',
+            version='1.0.0',
+            routes=[
+                get_route(_TestAPI.method_1),
+                get_route(_TestAPI.method_2),
+            ],
+        )
+
+    assert str(e.value) == (
+        'Title Dataclass for type '
+        "<class 'test_api_request_and_response_spec.test_raises_for_type_duplicates.<locals>.DuplicateTypes.Dataclass'>"
+        " is already used for another type: <class 'test_api_request_and_response_spec.Dataclass'>"
+    )

--- a/tests/winter_openapi/test_api_with_media_types_spec.py
+++ b/tests/winter_openapi/test_api_with_media_types_spec.py
@@ -65,11 +65,7 @@ def test_generate_spec_for_media_type_consumes():
                     'content': {
                         'application/xml': {
                             'schema': {
-                                'description': 'Data(field1: str)',
-                                'properties': {'field1': {'type': 'string'}},
-                                'required': ['field1'],
-                                'title': 'DataInput',
-                                'type': 'object',
+                                '$ref': '#/components/schemas/DataInput',
                             },
                         },
                     },
@@ -79,4 +75,17 @@ def test_generate_spec_for_media_type_consumes():
                 'tags': ['xml'],
             },
         },
+    }
+    assert result['components'] == {
+        'schemas': {
+            'DataInput': {
+                'description': 'Data(field1: str)',
+                'properties': {'field1': {'type': 'string'}},
+                'required': ['field1'],
+                'title': 'DataInput',
+                'type': 'object',
+            },
+        },
+        'parameters': {},
+        'responses': {},
     }

--- a/tests/winter_openapi/test_exception_spec.py
+++ b/tests/winter_openapi/test_exception_spec.py
@@ -54,27 +54,40 @@ class ProblemExistsExceptionDTO:
 
 
 @pytest.mark.parametrize(
-    'handler_return_type, handler_spec', [
+    'handler_return_type, handler_spec, expected_components', [
         (
             ProblemExistsExceptionDTO,
             {
                 'content': {
                     'application/json': {
                         'schema': {
-                            'description': 'ProblemExistsExceptionDTO(message: str)',
-                            'properties': {'message': {'type': 'string'}},
-                            'required': ['message'],
-                            'title': 'ProblemExistsExceptionDTO',
-                            'type': 'object',
+                            '$ref': '#/components/schemas/ProblemExistsExceptionDTO'
                         },
                     },
                 },
             },
+            {
+                'schemas': {
+                    'ProblemExistsExceptionDTO': {
+                        'description': 'ProblemExistsExceptionDTO(message: str)',
+                        'properties': {'message': {'type': 'string'}},
+                        'required': ['message'],
+                        'title': 'ProblemExistsExceptionDTO',
+                        'type': 'object',
+                    },
+                },
+                'parameters': {},
+                'responses': {},
+            }
         ),
-        (None, {'description': ''}),
+        (None, {'description': ''}, {'parameters': {}, 'responses': {}, 'schemas': {}}),
     ],
 )
-def test_exception_annotated_on_method_with_custom_handler_with_dto(handler_return_type, handler_spec):
+def test_exception_annotated_on_method_with_custom_handler_with_dto(
+    handler_return_type,
+    handler_spec,
+    expected_components,
+):
     @winter.web.problem(status=HTTPStatus.FORBIDDEN)
     class ProblemExistsException(Exception):
         pass
@@ -99,7 +112,7 @@ def test_exception_annotated_on_method_with_custom_handler_with_dto(handler_retu
     )
     # Assert
     assert result == {
-        'components': {'parameters': {}, 'responses': {}, 'schemas': {}},
+        'components': expected_components,
         'info': {'title': 'title', 'version': '1.0.0'},
         'openapi': '3.0.3',
         'paths': {

--- a/winter_openapi/generator.py
+++ b/winter_openapi/generator.py
@@ -8,8 +8,12 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import Set
+from typing import Tuple
+from typing import Type
+from typing import Union
 
 from django.http.response import HttpResponseBase
+from openapi_pydantic import schema_validate
 from openapi_pydantic.v3.v3_0_3 import Components
 from openapi_pydantic.v3.v3_0_3 import Info
 from openapi_pydantic.v3.v3_0_3 import MediaType as MediaTypeModel
@@ -18,12 +22,13 @@ from openapi_pydantic.v3.v3_0_3 import Operation
 from openapi_pydantic.v3.v3_0_3 import Parameter
 from openapi_pydantic.v3.v3_0_3 import PathItem
 from openapi_pydantic.v3.v3_0_3 import Paths
+from openapi_pydantic.v3.v3_0_3 import Reference
 from openapi_pydantic.v3.v3_0_3 import RequestBody
 from openapi_pydantic.v3.v3_0_3 import Response
 from openapi_pydantic.v3.v3_0_3 import Responses
+from openapi_pydantic.v3.v3_0_3 import Schema
 from openapi_pydantic.v3.v3_0_3 import Server
 from openapi_pydantic.v3.v3_0_3 import Tag
-from openapi_pydantic import schema_validate
 
 from winter.core import ComponentMethod
 from winter.web import MediaType
@@ -32,11 +37,38 @@ from winter.web.exceptions import MethodExceptionsManager
 from winter.web.request_body_annotation import RequestBodyAnnotation
 from winter.web.routing import Route
 from winter.web.routing import RouteAnnotation
-from winter_openapi.inspection.inspection import InspectorNotFound
 from winter_openapi.inspection.inspection import inspect_type
+from .inspection.inspection import InspectorNotFound
 from .inspectors import get_route_parameters_inspectors
 from .type_info_converter import convert_type_info_to_openapi_schema
 
+
+class SchemaRegistry:
+    def __init__(self):
+        self._schemas: Dict[Tuple[Type, bool], Schema] = {}
+        self._types_by_titles: Dict[str, Type] = {}
+
+    def get_schema_or_reference(self, type_: Type, output: bool) -> Union[Schema, Reference]:
+        schema = self._schemas.get((type_, output))
+        if not schema:
+            type_info = inspect_type(type_)
+            schema = convert_type_info_to_openapi_schema(type_info, output=output)
+            if not schema.title:
+                return schema
+            self._schemas[type_, output] = schema
+
+        if schema.title not in self._types_by_titles:
+            self._types_by_titles[schema.title] = type_
+        elif self._types_by_titles[schema.title] != type_:
+            raise ValueError(f'Title {schema.title} for type {type_} is already used for another type: {self._types_by_titles[schema.title]}')
+
+        return Reference(ref='#/components/schemas/' + schema.title)
+
+    def get_schemas(self) -> Dict[str, Schema]:
+        return {
+            schema.title: schema
+            for schema in self._schemas.values()
+        }
 
 def generate_openapi(
     title: str,
@@ -49,7 +81,7 @@ def generate_openapi(
 ) -> Dict[str, Any]:
     routes = list(routes)
     routes.sort(key=lambda r: r.url_path)
-    components = Components(responses=[], schemas=[], parameters=[])
+    schema_registry = SchemaRegistry()
     tags_ = [Tag(**tag) for tag in tags or []]
     tag_names = [tag_.name for tag_ in tags_]
     paths: Paths = {}
@@ -68,11 +100,21 @@ def generate_openapi(
             if url_path_tag:
                 path_tag_names.append(url_path_tag)
 
-        path_item = _get_openapi_path(routes=group_routes, operation_ids=operation_ids, tag_names=path_tag_names)
+        path_item = _get_openapi_path(
+            routes=group_routes,
+            operation_ids=operation_ids,
+            tag_names=path_tag_names,
+            schema_registry=schema_registry,
+        )
         paths[url_path_without_prefix] = path_item
 
     info = Info(title=title, version=version, description=description)
     servers_ = [Server(url=path_prefix)]
+    components = Components(
+        schemas=schema_registry.get_schemas(),
+        responses={},
+        parameters={},
+    )
     openapi = OpenAPI(info=info, servers=servers_, paths=paths, components=components, tags=tags_)
     openapi_dict = openapi.dict(by_alias=True, exclude_none=True)
     if validate:
@@ -80,26 +122,46 @@ def generate_openapi(
     return openapi_dict
 
 
-def _get_openapi_path(*, routes: Iterable[Route], operation_ids: Set[str], tag_names: Iterable[str]) -> PathItem:
+def _get_openapi_path(
+    *,
+    routes: Iterable[Route],
+    operation_ids: Set[str],
+    tag_names: Iterable[str],
+    schema_registry: SchemaRegistry,
+) -> PathItem:
     path = {}
-    for route_item in routes:
-        operation_id = route_item.method.full_name
+    for route in routes:
+        operation_id = route.method.full_name
         if operation_id in operation_ids:
             warnings.warn(f"Duplicate Operation ID {operation_id}")
         operation_ids.add(operation_id)
 
-        operation = _get_openapi_operation(route=route_item, operation_id=operation_id, tag_names=tag_names)
-        path[route_item.http_method.lower()] = operation
+        try:
+            operation = _get_openapi_operation(
+                route=route,
+                operation_id=operation_id,
+                tag_names=tag_names,
+                schema_registry=schema_registry,
+            )
+        except InspectorNotFound as e:
+            raise CanNotInspectType(route.method, e.hint_cls, str(e))
+        path[route.http_method.lower()] = operation
 
     return PathItem.parse_obj(path)
 
 
-def _get_openapi_operation(*, route: Route, operation_id: str, tag_names: Iterable[str]) -> Operation:
+def _get_openapi_operation(
+    *,
+    route: Route,
+    operation_id: str,
+    tag_names: Iterable[str],
+    schema_registry: SchemaRegistry,
+) -> Operation:
     summary = route.method.docstring.short_description
     description = route.method.docstring.long_description
     operation_parameters = get_route_parameters(route)
-    operation_request_body = get_request_body_parameters(route)
-    operation_responses = get_responses_schemas(route)
+    operation_request_body = get_request_body_parameters(route, schema_registry)
+    operation_responses = get_responses_schemas(route, schema_registry)
     return Operation(
         tags=tag_names,
         summary=summary,
@@ -111,15 +173,15 @@ def _get_openapi_operation(*, route: Route, operation_id: str, tag_names: Iterab
     )
 
 
-class CanNotInspectReturnType(Exception):
+class CanNotInspectType(Exception):
 
     def __init__(
         self,
         method: ComponentMethod,
-        return_type: Any,
+        type_: Any,
         message: str,
     ):
-        self._return_type = return_type
+        self._type = type_
         self._message = message
         self._method = method
 
@@ -129,7 +191,7 @@ class CanNotInspectReturnType(Exception):
     def __str__(self):
         component_cls = self._method.component.component_cls
         method_path = f'{component_cls.__module__}.{self._method.full_name}'
-        return f'{method_path}: -> {self._return_type}: {self._message}'
+        return f'{method_path}: -> {self._type}: {self._message}'
 
 
 def get_url_path_without_prefix(url_path: str, path_prefix: str) -> str:
@@ -170,7 +232,7 @@ def get_route_parameters(route: Route) -> List[Parameter]:
     return parameters
 
 
-def get_request_body_parameters(route: Route) -> Optional[RequestBody]:
+def get_request_body_parameters(route: Route, schema_registry: SchemaRegistry) -> Optional[RequestBody]:
     method = route.method
     request_body_annotation = method.annotations.get_one_or_none(RequestBodyAnnotation)
     if request_body_annotation is None:
@@ -178,31 +240,30 @@ def get_request_body_parameters(route: Route) -> Optional[RequestBody]:
 
     description = method.docstring.short_description
     argument = method.get_argument(request_body_annotation.argument_name)
-    type_info = inspect_type(argument.type_)
-    media_type_schema = convert_type_info_to_openapi_schema(type_info, output=False)
+    reference = schema_registry.get_schema_or_reference(argument.type_, output=False)
 
     route_annotation = method.annotations.get_one_or_none(RouteAnnotation)
     consumes = route_annotation.consumes or [MediaType.APPLICATION_JSON]
     content = {
-        str(consume): MediaTypeModel(media_type_schema=media_type_schema)
+        str(consume): MediaTypeModel(media_type_schema=reference)
         for consume in consumes
     }
     return RequestBody(description=description, content=content)
 
 
-def get_responses_schemas(route: Route) -> Responses:
+def get_responses_schemas(route: Route, schema_registry: SchemaRegistry) -> Responses:
     responses: Responses = {}
     http_method = route.http_method
     response_status = str(get_response_status(http_method, route.method))
 
-    responses[response_status] = _build_response_schema(route.method)
+    responses[response_status] = _build_response_schema(route.method, schema_registry)
     method_exceptions_manager = MethodExceptionsManager(route.method)
 
     for exception_cls in method_exceptions_manager.declared_exception_classes:
         handler = method_exceptions_manager.get_handler(exception_cls)
         handle_method = ComponentMethod.get_or_create(handler.__class__.handle)
         response_status = str(get_response_status(http_method, handle_method))
-        responses[response_status] = _build_response_exception_handler_schema(handle_method)
+        responses[response_status] = _build_response_exception_handler_schema(handle_method, schema_registry)
     return responses
 
 
@@ -258,39 +319,29 @@ def determine_path_prefix(url_paths: List[str]) -> str:
     return '/' + '/'.join(common)
 
 
-def _build_response_schema(method: ComponentMethod) -> Response:
+def _build_response_schema(method: ComponentMethod, schema_registry: SchemaRegistry) -> Response:
     return_value_type = method.return_value_type
     if _is_abstract_or_none_return_type(return_value_type):
         return Response(description='')
 
-    type_info = _get_inspect_type(method, return_value_type)
-    media_type_schema = convert_type_info_to_openapi_schema(type_info, output=True)
+    reference = schema_registry.get_schema_or_reference(return_value_type, output=True)
     route_annotation = method.annotations.get_one_or_none(RouteAnnotation)
     produces = route_annotation.produces or [MediaType.APPLICATION_JSON]
     content = {
-        str(produce): MediaTypeModel(media_type_schema=media_type_schema)
+        str(produce): MediaTypeModel(media_type_schema=reference)
         for produce in produces
     }
     return Response(description='', content=content)
 
 
-def _build_response_exception_handler_schema(method: ComponentMethod) -> Response:
+def _build_response_exception_handler_schema(method: ComponentMethod, schema_registry: SchemaRegistry) -> Response:
     return_value_type = method.return_value_type
     if _is_abstract_or_none_return_type(return_value_type):
         return Response(description='')
 
-    type_info = _get_inspect_type(method, return_value_type)
-    media_type_schema = convert_type_info_to_openapi_schema(type_info, output=True)
-    content = {str(MediaType.APPLICATION_JSON): MediaTypeModel(media_type_schema=media_type_schema)}
+    reference = schema_registry.get_schema_or_reference(return_value_type, output=True)
+    content = {str(MediaType.APPLICATION_JSON): MediaTypeModel(media_type_schema=reference)}
     return Response(description='', content=content)
-
-
-def _get_inspect_type(method, return_value_type):
-    try:
-        type_info = inspect_type(return_value_type)
-    except InspectorNotFound as e:
-        raise CanNotInspectReturnType(method, return_value_type, str(e))
-    return type_info
 
 
 def _is_abstract_or_none_return_type(return_value_type):

--- a/winter_openapi/inspection/type_info.py
+++ b/winter_openapi/inspection/type_info.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Dict
 from typing import Optional
+from typing import Type
 
 from .data_formats import DataFormat
 from .data_types import DataTypes
@@ -11,6 +12,7 @@ from .data_types import DataTypes
 @dataclass
 class TypeInfo:
     type_: DataTypes
+    hint_class: Type
     format_: Optional[DataFormat] = None
     child: Optional['TypeInfo'] = None
     nullable: bool = False

--- a/winter_openapi/inspectors/page_inspector.py
+++ b/winter_openapi/inspectors/page_inspector.py
@@ -1,9 +1,8 @@
 import dataclasses
 from typing import List
+from typing import Optional
 
 from winter.data.pagination import Page
-from winter_openapi.inspection.data_formats import DataFormat
-from winter_openapi.inspection.data_types import DataTypes
 from winter_openapi.inspection.type_info import TypeInfo
 from winter_openapi.inspectors.standard_types_inspectors import inspect_type
 from winter_openapi.inspectors.standard_types_inspectors import register_type_inspector
@@ -18,22 +17,33 @@ def inspect_page(hint_class) -> TypeInfo:
     child_type_info = inspect_type(child_class)
     title = child_type_info.title or child_type_info.type_.capitalize()
 
-    return TypeInfo(
-        type_=DataTypes.OBJECT,
-        title=f'PageOf{title}',
-        properties={
-            'meta': TypeInfo(
-                type_=DataTypes.OBJECT,
-                title=f'PageMetaOf{title}',
-                properties={
-                    'total_count': TypeInfo(type_=DataTypes.INTEGER),
-                    'limit': TypeInfo(type_=DataTypes.INTEGER, nullable=True),
-                    'offset': TypeInfo(type_=DataTypes.INTEGER, nullable=True),
-                    'previous': TypeInfo(type_=DataTypes.STRING, format_=DataFormat.URI, nullable=True),
-                    'next': TypeInfo(type_=DataTypes.STRING, format_=DataFormat.URI, nullable=True),
-                    **{extra_field.name: inspect_type(extra_field.type) for extra_field in extra_fields},
+    PageMetaDataclass = dataclasses.dataclass(
+        type(
+            f'PageMetaOf{title}',
+            (),
+            {
+                '__annotations__': {
+                    'total_count': int,
+                    'limit': Optional[int],
+                    'offset': Optional[int],
+                    'previous': Optional[str],
+                    'next': Optional[str],
+                    **{extra_field.name: extra_field.type for extra_field in extra_fields},
                 },
-            ),
-            'objects': inspect_type(List[child_class]),
-        },
+            },
+        ),
     )
+    PageDataclass = dataclasses.dataclass(
+        type(
+            f'PageOf{title}',
+            (),
+            {
+                '__annotations__': {
+                    'meta': PageMetaDataclass,
+                    'objects': List[child_class],
+                },
+            },
+        ),
+    )
+
+    return inspect_type(PageDataclass)

--- a/winter_openapi/inspectors/page_inspector.py
+++ b/winter_openapi/inspectors/page_inspector.py
@@ -33,6 +33,7 @@ def inspect_page(hint_class) -> TypeInfo:
             },
         ),
     )
+    PageMetaDataclass.__doc__ = ''
     PageDataclass = dataclasses.dataclass(
         type(
             f'PageOf{title}',
@@ -45,5 +46,6 @@ def inspect_page(hint_class) -> TypeInfo:
             },
         ),
     )
+    PageDataclass.__doc__ = ''
 
     return inspect_type(PageDataclass)

--- a/winter_openapi/inspectors/page_position_argument_inspector.py
+++ b/winter_openapi/inspectors/page_position_argument_inspector.py
@@ -1,4 +1,5 @@
 from typing import List
+from typing import TYPE_CHECKING
 
 from openapi_pydantic.v3.v3_0_3 import Parameter
 from openapi_pydantic.v3.v3_0_3 import Schema
@@ -9,6 +10,9 @@ from winter.web.pagination.page_position_argument_resolver import PagePositionAr
 from winter.web.routing import Route
 from winter_openapi.inspection.data_types import DataTypes
 from .route_parameters_inspector import RouteParametersInspector
+
+if TYPE_CHECKING:
+    from winter_openapi.generator import SchemaRegistry
 
 
 class PagePositionArgumentsInspector(RouteParametersInspector):
@@ -31,7 +35,7 @@ class PagePositionArgumentsInspector(RouteParametersInspector):
             param_schema=Schema(type=DataTypes.INTEGER)
         )
 
-    def inspect_parameters(self, route: 'Route') -> List[Parameter]:
+    def inspect_parameters(self, route: 'Route', schema_registry: 'SchemaRegistry') -> List[Parameter]:
         parameters = []
         has_page_position_argument = any(argument.type_ == PagePosition for argument in route.method.arguments)
         if not has_page_position_argument:

--- a/winter_openapi/inspectors/query_parameters_inspector.py
+++ b/winter_openapi/inspectors/query_parameters_inspector.py
@@ -1,24 +1,23 @@
+import dataclasses
 from typing import List
+from typing import TYPE_CHECKING
 from typing import Tuple
 
-import dataclasses
 from openapi_pydantic import Parameter
 
 from winter.core import ComponentMethodArgument
 from winter.web.query_parameters import QueryParameter
 from winter.web.query_parameters.query_parameters_annotation import QueryParametersAnnotation
 from winter.web.routing import Route
-from winter_openapi.inspection import DataTypes
-from winter_openapi.inspection import TypeInfo
-from winter_openapi.inspection.inspection import InspectorNotFound
-from winter_openapi.inspection.inspection import inspect_type
-from winter_openapi.inspectors.route_parameters_inspector import RouteParametersInspector
-from winter_openapi.type_info_converter import convert_type_info_to_openapi_schema
+from .route_parameters_inspector import RouteParametersInspector
+
+if TYPE_CHECKING:
+    from winter_openapi.generator import SchemaRegistry
 
 
 class QueryParametersInspector(RouteParametersInspector):
 
-    def inspect_parameters(self, route: 'Route') -> List[Parameter]:
+    def inspect_parameters(self, route: 'Route', schema_registry: 'SchemaRegistry') -> List[Parameter]:
         parameters = []
 
         annotation = route.method.annotations.get_one_or_none(QueryParametersAnnotation)
@@ -27,11 +26,19 @@ class QueryParametersInspector(RouteParametersInspector):
             query_parameters_map = {query_parameter.name: query_parameter for query_parameter in query_parameters}
             for field in dataclasses.fields(annotation.argument.type_):
                 query_parameter = query_parameters_map[field.name]
-                openapi_parameter = self._convert_dataclass_field_to_openapi_parameter(field, query_parameter)
+                openapi_parameter = self._convert_dataclass_field_to_openapi_parameter(
+                    field,
+                    query_parameter,
+                    schema_registry,
+                )
                 parameters.append(openapi_parameter)
         else:
             for argument, query_parameter in self._query_arguments(route):
-                openapi_parameter = self._convert_argument_to_openapi_parameter(argument, query_parameter)
+                openapi_parameter = self._convert_argument_to_openapi_parameter(
+                    argument,
+                    query_parameter,
+                    schema_registry,
+                )
                 parameters.append(openapi_parameter)
 
         return parameters
@@ -40,17 +47,12 @@ class QueryParametersInspector(RouteParametersInspector):
         self,
         argument: ComponentMethodArgument,
         query_parameter: QueryParameter,
+        schema_registry: 'SchemaRegistry',
     ) -> Parameter:
-        try:
-            type_info = inspect_type(argument.type_)
-            description = argument.description
-        except InspectorNotFound:
-            type_info = TypeInfo(DataTypes.STRING)
-            description = 'winter_openapi has failed to inspect the parameter'
-        schema = convert_type_info_to_openapi_schema(type_info, output=False)
+        schema = schema_registry.get_schema_or_reference(argument.type_, output=False)
         return Parameter(
             name=query_parameter.name,
-            description=description,
+            description=argument.description,
             required=argument.required,
             param_in='query',
             default=argument.get_default(None),
@@ -62,17 +64,12 @@ class QueryParametersInspector(RouteParametersInspector):
         self,
         field: dataclasses.Field,
         query_parameter: QueryParameter,
+        schema_registry: 'SchemaRegistry',
     ) -> Parameter:
-        try:
-            type_info = inspect_type(field.type)
-            description = ''
-        except InspectorNotFound:
-            type_info = TypeInfo(DataTypes.STRING)
-            description = 'winter_openapi has failed to inspect the parameter'
-        schema = convert_type_info_to_openapi_schema(type_info, output=False)
+        schema = schema_registry.get_schema_or_reference(field.type, output=False)
         return Parameter(
             name=query_parameter.name,
-            description=description,
+            description='',
             required=field.default is dataclasses.MISSING,
             param_in='query',
             default=field.default,

--- a/winter_openapi/inspectors/route_parameters_inspector.py
+++ b/winter_openapi/inspectors/route_parameters_inspector.py
@@ -1,15 +1,20 @@
 import abc
+import logging
 from typing import List
+from typing import TYPE_CHECKING
 
 from openapi_pydantic import Parameter
 
 from winter.web.routing import Route
-import logging
 
-class RouteParametersInspector(abc.ABC):
+if TYPE_CHECKING:
+    from winter_openapi.generator import SchemaRegistry
+
+
+class RouteParametersInspector(abc.ABC):  # pragma: no cover
 
     @abc.abstractmethod
-    def inspect_parameters(self, route: 'Route') -> List[Parameter]:  # pragma: no cover
+    def inspect_parameters(self, route: 'Route', schema_registry: 'SchemaRegistry') -> List[Parameter]:
         return []
 
 

--- a/winter_openapi/inspectors/standard_types_inspectors.py
+++ b/winter_openapi/inspectors/standard_types_inspectors.py
@@ -28,73 +28,73 @@ from winter_openapi.inspection.type_info import TypeInfo
 # noinspection PyUnusedLocal
 @register_type_inspector(bool)
 def inspect_bool(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.BOOLEAN)
+    return TypeInfo(type_=DataTypes.BOOLEAN, hint_class=hint_class)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(int)
 def inspect_int(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.INTEGER, format_=DataFormat.INT32)
+    return TypeInfo(type_=DataTypes.INTEGER, hint_class=hint_class, format_=DataFormat.INT32)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(bytes)
 def inspect_bytes(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.STRING, format_=DataFormat.BASE64)
+    return TypeInfo(type_=DataTypes.STRING, hint_class=hint_class, format_=DataFormat.BASE64)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(str)
 def inspect_str(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.STRING)
+    return TypeInfo(type_=DataTypes.STRING, hint_class=hint_class)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(float)
 def inspect_float(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.NUMBER, format_=DataFormat.FLOAT)
+    return TypeInfo(type_=DataTypes.NUMBER, format_=DataFormat.FLOAT, hint_class=hint_class)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(dict)
 def inspect_dict(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.OBJECT)
+    return TypeInfo(type_=DataTypes.OBJECT, hint_class=hint_class)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(object, checker=is_type_var)
 def inspect_type_var(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.ANY)
+    return TypeInfo(type_=DataTypes.ANY, hint_class=hint_class)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(object, checker=is_any)
 def inspect_any(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.ANY)
+    return TypeInfo(type_=DataTypes.ANY, hint_class=hint_class)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(decimal.Decimal)
 def inspect_decimal(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.STRING, format_=DataFormat.DECIMAL)
+    return TypeInfo(type_=DataTypes.STRING, hint_class=hint_class, format_=DataFormat.DECIMAL)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(uuid.UUID)
 def inspect_uuid(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.STRING, format_=DataFormat.UUID)
+    return TypeInfo(type_=DataTypes.STRING, hint_class=hint_class, format_=DataFormat.UUID)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(datetime.datetime)
 def inspect_datetime(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.STRING, format_=DataFormat.DATETIME)
+    return TypeInfo(type_=DataTypes.STRING, hint_class=hint_class, format_=DataFormat.DATETIME)
 
 
 # noinspection PyUnusedLocal
 @register_type_inspector(datetime.date)
 def inspect_date(hint_class) -> TypeInfo:
-    return TypeInfo(type_=DataTypes.STRING, format_=DataFormat.DATE)
+    return TypeInfo(type_=DataTypes.STRING, hint_class=hint_class, format_=DataFormat.DATE)
 
 
 # noinspection PyUnusedLocal
@@ -102,10 +102,14 @@ def inspect_date(hint_class) -> TypeInfo:
 def inspect_iterable(hint_class) -> TypeInfo:
     args = typing.get_args(hint_class)
     if not args:
-        return TypeInfo(type_=DataTypes.ARRAY, child=TypeInfo(type_=DataTypes.ANY))
+        return TypeInfo(
+            type_=DataTypes.ARRAY,
+            hint_class=hint_class,
+            child=TypeInfo(type_=DataTypes.ANY, hint_class=typing.Any),
+        )
     child_class = args[0]
     child_schema = inspect_type(child_class)
-    return TypeInfo(type_=DataTypes.ARRAY, child=child_schema)
+    return TypeInfo(type_=DataTypes.ARRAY, hint_class=hint_class, child=child_schema)
 
 
 @register_type_inspector(enum.IntEnum, StrEnum, enum.Enum)
@@ -117,8 +121,9 @@ def inspect_enum(enum_class: Type[enum.Enum]) -> TypeInfo:
     if len(enum_value_types) == 1:
         schema = inspect_type(enum_value_types.pop())
     else:
-        schema = TypeInfo(type_=DataTypes.STRING)
+        schema = TypeInfo(type_=DataTypes.STRING, hint_class=enum_class)
     schema.enum = enum_values
+    schema.hint_class = enum_class
     return schema
 
 
@@ -127,6 +132,7 @@ def inspect_optional(hint_class) -> TypeInfo:
     child_type = hint_class.__args__[0]
     schema = inspect_type(child_type)
     schema.nullable = True
+    schema.hint_class = hint_class
     return schema
 
 
@@ -156,6 +162,7 @@ def inspect_dataclass(hint_class) -> TypeInfo:
 
     return TypeInfo(
         type_=DataTypes.OBJECT,
+        hint_class=hint_class,
         properties=properties,
         properties_defaults=defaults,
         title=title,

--- a/winter_openapi/type_info_converter.py
+++ b/winter_openapi/type_info_converter.py
@@ -26,9 +26,6 @@ def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool) -> Sch
     if value.child is not None:
         data['items'] = convert_type_info_to_openapi_schema(value.child, output=output)
 
-    if value.nullable:
-        data['nullable'] = True
-
     if value.enum is not None:
         data['enum'] = value.enum
 
@@ -53,4 +50,13 @@ def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool) -> Sch
     if required_properties:
         data['required'] = required_properties
 
-    return Schema(**data)
+    schema = Schema(**data)
+
+    if value.nullable:
+        if value.type_.value == 'object':
+            # https://stackoverflow.com/questions/40920441/how-to-specify-a-property-can-be-null-or-a-reference-with-swagger
+            schema = Schema(nullable=True, allOf=[schema])
+        else:
+            schema.nullable = True
+
+    return schema

--- a/winter_openapi/type_info_converter.py
+++ b/winter_openapi/type_info_converter.py
@@ -55,6 +55,7 @@ def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool) -> Sch
     if value.nullable:
         if value.type_.value == 'object':
             # https://stackoverflow.com/questions/40920441/how-to-specify-a-property-can-be-null-or-a-reference-with-swagger
+            # Better solution, but not implemented yet https://github.com/OpenAPITools/openapi-generator/issues/9083
             schema = Schema(nullable=True, allOf=[schema])
         else:
             schema.nullable = True

--- a/winter_openapi/type_info_converter.py
+++ b/winter_openapi/type_info_converter.py
@@ -1,10 +1,14 @@
+from typing import TYPE_CHECKING
+
 from openapi_pydantic.v3.v3_0_3 import Schema
 
 from winter_openapi.inspection import DataTypes
 from winter_openapi.inspection import TypeInfo
 
+if TYPE_CHECKING:
+    from winter_openapi.generator import SchemaRegistry
 
-def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool) -> Schema:
+def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool, schema_registry: 'SchemaRegistry') -> Schema:
     if value.type_ == DataTypes.ANY:
         return Schema(
             description='Can be any value - string, number, boolean, array or object.',
@@ -12,8 +16,12 @@ def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool) -> Sch
         )
 
     data = {
-        'type': value.type_.value
+        'type': value.type_,
     }
+
+    if value.type_ != DataTypes.OBJECT and value.nullable:
+        data['nullable'] = True
+
     if value.title:
         data['title'] = value.title if output else f'{value.title}Input'
 
@@ -21,10 +29,10 @@ def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool) -> Sch
         data['description'] = value.description
 
     if value.format_ is not None:
-        data['schema_format'] = value.format_.value
+        data['schema_format'] = value.format_
 
     if value.child is not None:
-        data['items'] = convert_type_info_to_openapi_schema(value.child, output=output)
+        data['items'] = schema_registry.get_schema_or_reference(value.child.hint_class, output=output)
 
     if value.enum is not None:
         data['enum'] = value.enum
@@ -32,7 +40,7 @@ def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool) -> Sch
     if value.properties:
         sorted_keys = sorted(value.properties.keys())
         data['properties'] = {
-            key: convert_type_info_to_openapi_schema(value.properties[key], output=output)
+            key: schema_registry.get_schema_or_reference(value.properties[key].hint_class, output=output)
             for key in sorted_keys
         }
 
@@ -50,14 +58,4 @@ def convert_type_info_to_openapi_schema(value: TypeInfo, *, output: bool) -> Sch
     if required_properties:
         data['required'] = required_properties
 
-    schema = Schema(**data)
-
-    if value.nullable:
-        if value.type_.value == 'object':
-            # https://stackoverflow.com/questions/40920441/how-to-specify-a-property-can-be-null-or-a-reference-with-swagger
-            # Better solution, but not implemented yet https://github.com/OpenAPITools/openapi-generator/issues/9083
-            schema = Schema(nullable=True, allOf=[schema])
-        else:
-            schema.nullable = True
-
-    return schema
+    return Schema(**data)


### PR DESCRIPTION
- Schemas extracted to OpenAPI components, are always referenced
- Use workaround for nullable fields so that openapi-generator generate less duplicates