### PR TITLE
Winter was made compatible with the latest version of 'uritemplate'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [30.0.1] - 2025-06-03
+- Winter was made compatible with the latest version of 'uritemplate'
+- 'uritemplate' doesn't follow semantic versioning so exact version was pinned
+
 ## [30.0.0] - 2025-02-27
 - Dropped support of Python earlier than 3.11
 - Dropped support of Django earlier than 4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "winter"
-version = "30.0.0"
+version = "30.0.1"
 homepage = "https://github.com/WinterFramework/winter"
 description = "Web Framework with focus on python typing, dataclasses and modular design"
 authors = ["Alexander Egorov <mofr@zond.org>"]
@@ -39,7 +39,7 @@ StrEnum = "^0.4.8"
 openapi-pydantic = ">=0.5.0, <0.6"
 pydantic = ">=1.10, <2"
 openapi-spec-validator = ">=0.5.7, <1"
-uritemplate = ">=4.1.1, <5"
+uritemplate = "==4.2.0"  # Lib doesn't follow semantic versioning
 httpx = ">=0.24.1, <0.28"
 
 [tool.poetry.dev-dependencies]

--- a/winter/web/routing/route.py
+++ b/winter/web/routing/route.py
@@ -4,6 +4,7 @@ from typing import Set
 
 import uritemplate
 from uritemplate import URITemplate
+from uritemplate.variable import Operator
 
 from winter.core import ComponentMethod
 from winter.web.query_parameters import MapQueryParameterAnnotation
@@ -42,7 +43,7 @@ class Route:
         query_variables = (
             variable
             for variable in URITemplate(self._url_path_with_query_parameters).variables
-            if variable.operator == '?'
+            if variable.operator == Operator.form_style_query
         )
         for variable in query_variables:
             for variable_name, variable_params in variable.variables:


### PR DESCRIPTION
Winter was made compatible with the latest version of 'uritemplate'.
'uritemplate' doesn't follow semantic versioning so exact version was pinned